### PR TITLE
make Read a semiprivate method

### DIFF
--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -44,7 +44,7 @@ class BaseBackend(AbstractContextManager):
         """Retrieve assets for point."""
 
     @abc.abstractmethod
-    def read(self) -> MosaicJSON:
+    def _read(self) -> MosaicJSON:
         """Fetch mosaic definition"""
 
     @property

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -35,7 +35,7 @@ class DynamoDBBackend(BaseBackend):
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
         else:
-            self.mosaic_def = self.read()
+            self.mosaic_def = self._read()
 
     def tile(self, x: int, y: int, z: int) -> List[str]:
         """Retrieve assets for tile."""
@@ -104,7 +104,7 @@ class DynamoDBBackend(BaseBackend):
                     batch.put_item(item)
 
     @functools.lru_cache(maxsize=512)
-    def read(self) -> MosaicJSON:
+    def _read(self) -> MosaicJSON:
         """Get Mosaic definition info."""
         meta = self._fetch_dynamodb("-1")
 

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -31,7 +31,7 @@ class FileBackend(BaseBackend):
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
         else:
-            self.mosaic_def = self.read(**kwargs)
+            self.mosaic_def = self._read(**kwargs)
 
     def tile(self, x: int, y: int, z: int) -> List[str]:
         """Retrieve assets for tile."""
@@ -58,7 +58,7 @@ class FileBackend(BaseBackend):
         raise NotImplementedError
 
     @functools.lru_cache(maxsize=512)
-    def read(self, gzip: bool = None) -> MosaicJSON:
+    def _read(self, gzip: bool = None) -> MosaicJSON:
         """Get mosaicjson document."""
         with open(self.path, "rb") as f:
             body = f.read()

--- a/cogeo_mosaic/backends/http.py
+++ b/cogeo_mosaic/backends/http.py
@@ -28,7 +28,7 @@ class HttpBackend(BaseBackend):
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
         else:
-            self.mosaic_def = self.read(**kwargs)
+            self.mosaic_def = self._read(**kwargs)
 
     def tile(self, x: int, y: int, z: int) -> List[str]:
         """Retrieve assets for tile."""
@@ -50,7 +50,7 @@ class HttpBackend(BaseBackend):
         raise NotImplementedError
 
     @functools.lru_cache(maxsize=512)
-    def read(self, gzip: bool = None) -> MosaicJSON:
+    def _read(self, gzip: bool = None) -> MosaicJSON:
         """Get mosaicjson document."""
         body = requests.get(self.url).content
 

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -37,7 +37,7 @@ class S3Backend(BaseBackend):
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
         else:
-            self.mosaic_def = self.read(**kwargs)
+            self.mosaic_def = self._read(**kwargs)
 
     def tile(self, x: int, y: int, z: int) -> List[str]:
         """Retrieve assets for tile."""
@@ -65,7 +65,7 @@ class S3Backend(BaseBackend):
         raise NotImplementedError
 
     @functools.lru_cache(maxsize=512)
-    def read(self, gzip: bool = None) -> MosaicJSON:
+    def _read(self, gzip: bool = None) -> MosaicJSON:
         """Get mosaicjson document."""
         body = _aws_get_data(self.key, self.bucket, client=self.client)
 


### PR DESCRIPTION
Ref https://github.com/developmentseed/cogeo-mosaic/pull/44#discussion_r413003857

As of today, the `read` method as no use outside its class and could be (IMO) misleading. This PR update the `read` method to a semiprivate method (add `_` prefix) to indicate to the user the `method is intended to be private`

Thanks @kylebarron and @geospatial-jeff for the feedback 