### PR TITLE
Composable CLI

### DIFF
--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -222,7 +222,7 @@ class MosaicJSON(BaseModel):
         return cls._create_mosaic(features, quiet=quiet, **kwargs)
 
     @classmethod
-    def from_features(cls, **kwargs):
+    def from_features(cls, features, **kwargs):
         """
         Create mosaicjson from a set of GeoJSON Features.
 
@@ -239,4 +239,4 @@ class MosaicJSON(BaseModel):
             Mosaic definition.
 
         """
-        return cls._create_mosaic(**kwargs)
+        return cls._create_mosaic(features, **kwargs)

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -9,7 +9,7 @@ import mercantile
 from pygeos import STRtree, polygons, total_bounds
 from supermercado import burntiles
 
-from cogeo_mosaic.utils import get_footprints, _intersect_percent
+from cogeo_mosaic.utils import get_footprints, _intersect_percent, find_zooms
 
 from pydantic import BaseModel, Field
 
@@ -70,8 +70,8 @@ class MosaicJSON(BaseModel):
     def _create_mosaic(
         cls,
         features: Sequence[Dict],
-        minzoom: Optional[int] = None,
-        maxzoom: Optional[int] = None,
+        minzoom: int,
+        maxzoom: int,
         quadkey_zoom: Optional[int] = None,
         accessor: Callable[[Dict], str] = default_accessor,
         version: str = "0.0.2",
@@ -85,9 +85,9 @@ class MosaicJSON(BaseModel):
         ----------
         features : List, required
             List of GeoJSON features.
-        minzoom: int, optional
+        minzoom: int, required
             Force mosaic min-zoom.
-        maxzoom: int, optional
+        maxzoom: int, required
             Force mosaic max-zoom.
         quadkey_zoom: int, optional
             Force mosaic quadkey zoom.
@@ -106,34 +106,6 @@ class MosaicJSON(BaseModel):
             Mosaic definition.
 
         """
-        if minzoom is None:
-            try:
-                minzoom = {feat["properties"]["minzoom"] for feat in features}
-            except KeyError:
-                msg = "minzoom arg not provided and features lacking metadata"
-                raise ValueError(msg)
-            if len(minzoom) > 1:
-                warnings.warn(
-                    "Multiple MinZoom, Assets different minzoom values", UserWarning
-                )
-
-            minzoom = max(minzoom)
-
-        if maxzoom is None:
-            try:
-                maxzoom = {feat["properties"]["maxzoom"] for feat in features}
-            except KeyError:
-                msg = "maxzoom arg not provided and features lacking metadata"
-                raise ValueError(msg)
-
-            if len(maxzoom) > 1:
-                warnings.warn(
-                    "Multiple MaxZoom, Assets have multiple resolution values",
-                    UserWarning,
-                )
-
-            maxzoom = max(maxzoom)
-
         quadkey_zoom = quadkey_zoom or minzoom
 
         if not quiet:
@@ -187,7 +159,13 @@ class MosaicJSON(BaseModel):
 
     @classmethod
     def from_urls(
-        cls, urls: Sequence[str], max_threads: int = 20, quiet: bool = True, **kwargs,
+        cls,
+        urls: Sequence[str],
+        minzoom: Optional[int] = None,
+        maxzoom: Optional[int] = None,
+        max_threads: int = 20,
+        quiet: bool = True,
+        **kwargs,
     ):
         """
         Create mosaicjson from url of COGs.
@@ -215,14 +193,18 @@ class MosaicJSON(BaseModel):
         """
         features = get_footprints(urls, max_threads=max_threads, quiet=quiet)
 
+        minzoom, maxzoom = find_zooms(features, minzoom, maxzoom)
+
         datatype = {feat["properties"]["datatype"] for feat in features}
         if len(datatype) > 1:
             raise Exception("Dataset should have the same data type")
 
-        return cls._create_mosaic(features, quiet=quiet, **kwargs)
+        return cls._create_mosaic(
+            features, minzoom=minzoom, maxzoom=maxzoom, quiet=quiet, **kwargs
+        )
 
     @classmethod
-    def from_features(cls, features: Sequence[Dict], **kwargs):
+    def from_features(cls, features: Sequence[Dict], minzoom, maxzoom, **kwargs):
         """
         Create mosaicjson from a set of GeoJSON Features.
 
@@ -239,4 +221,4 @@ class MosaicJSON(BaseModel):
             Mosaic definition.
 
         """
-        return cls._create_mosaic(features, **kwargs)
+        return cls._create_mosaic(features, minzoom, maxzoom, **kwargs)

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -222,7 +222,7 @@ class MosaicJSON(BaseModel):
         return cls._create_mosaic(features, quiet=quiet, **kwargs)
 
     @classmethod
-    def from_features(cls, features, **kwargs):
+    def from_features(cls, features: Sequence[Dict], **kwargs):
         """
         Create mosaicjson from a set of GeoJSON Features.
 

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -66,9 +66,10 @@ def create(
     quiet,
 ):
     """Create mosaic definition file."""
-    features = json.load(input_files)
+    features = json.load(input_files)['features']
+    minzoom, maxzoom = find_zooms(features, minzoom, maxzoom)
     mosaicjson = MosaicJSON.from_features(
-        features['features'],
+        features,
         minzoom=minzoom,
         maxzoom=maxzoom,
         quadkey_zoom=quadkey_zoom,

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -26,7 +26,7 @@ def cogeo_cli():
     pass
 
 
-@cogeo_cli.command(short_help="Create mosaic definition from list of files")
+@cogeo_cli.command(short_help="Create mosaic definition from features")
 @click.argument("input_files", type=click.File(mode="r"), default="-")
 @click.option("--output", "-o", type=click.Path(exists=False), help="Output file name")
 @click.option(
@@ -73,9 +73,9 @@ def create(
     quiet,
 ):
     """Create mosaic definition file."""
-    input_files = input_files.read().splitlines()
-    mosaicjson = MosaicJSON.from_urls(
-        input_files,
+    features = json.load(input_files)
+    mosaicjson = MosaicJSON.from_features(
+        features,
         minzoom=minzoom,
         maxzoom=maxzoom,
         quadkey_zoom=quadkey_zoom,
@@ -122,7 +122,7 @@ def update(input_files, input_mosaic, output, min_tile_cover, threads):
         click.echo(json.dumps(mosaicjson))
 
 
-@cogeo_cli.command(short_help="Create geojson from list of files")
+@cogeo_cli.command(short_help="Create features from list of assets")
 @click.argument("input_files", type=click.File(mode="r"), default="-")
 @click.option("--output", "-o", type=click.Path(exists=False), help="Output file name")
 @click.option(

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -49,12 +49,6 @@ def cogeo_cli():
     "--tile-cover-sort", help="Sort files by covering %", is_flag=True, default=False
 )
 @click.option(
-    "--threads",
-    type=int,
-    default=lambda: os.environ.get("MAX_THREADS", multiprocessing.cpu_count() * 5),
-    help="threads",
-)
-@click.option(
     "--quiet",
     "-q",
     help="Remove progressbar and other non-error output.",
@@ -69,19 +63,17 @@ def create(
     quadkey_zoom,
     min_tile_cover,
     tile_cover_sort,
-    threads,
     quiet,
 ):
     """Create mosaic definition file."""
     features = json.load(input_files)
     mosaicjson = MosaicJSON.from_features(
-        features,
+        features['features'],
         minzoom=minzoom,
         maxzoom=maxzoom,
         quadkey_zoom=quadkey_zoom,
         minimum_tile_cover=min_tile_cover,
         tile_cover_sort=tile_cover_sort,
-        max_threads=threads,
         quiet=quiet,
     )
 

--- a/cogeo_mosaic/utils.py
+++ b/cogeo_mosaic/utils.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Tuple, Sequence
 
 import os
 import sys
+import warnings
 import logging
 import functools
 from concurrent import futures
@@ -249,3 +250,51 @@ def update_mosaic(
     ]
 
     return mosaic_def
+
+def find_zooms(features, minzoom=None, maxzoom=None):
+    """Find minzoom and maxzoom from features
+
+    Attributes
+    ----------
+    urls : List, required
+        List of COG urls.
+    minzoom: int, optional
+        Force mosaic min-zoom.
+    maxzoom: int, optional
+        Force mosaic max-zoom.
+
+    Returns
+    -------
+    minzoom, maxzoom : int, int
+        minzoom and maxzoom of features
+    """
+    if minzoom and maxzoom:
+        return minzoom, maxzoom
+
+    if minzoom is None:
+        try:
+            minzoom = {feat["properties"]["minzoom"] for feat in features}
+        except KeyError:
+            msg = "minzoom is a required argument when not used with footprint"
+            raise ValueError(msg)
+        if len(minzoom) > 1:
+            warnings.warn(
+                "Multiple MinZoom, Assets different minzoom values", UserWarning
+            )
+
+        minzoom = max(minzoom)
+
+    if maxzoom is None:
+        try:
+            maxzoom = {feat["properties"]["maxzoom"] for feat in features}
+        except KeyError:
+            msg = "maxzoom is a required argument when not used with footprint"
+            raise ValueError(msg)
+
+        if len(maxzoom) > 1:
+            warnings.warn(
+                "Multiple MaxZoom, Assets have multiple resolution values",
+                UserWarning,
+            )
+
+        maxzoom = max(maxzoom)


### PR DESCRIPTION
This is a small refactor to have a really clean, composable CLI:
```
> echo "tests/fixtures/cog1.tif" | cogeo-mosaic footprint | cogeo-mosaic create
Get quadkey list for zoom: 7
Feed Quadkey index
{"mosaicjson": "0.0.2", "version": "1.0.0", "minzoom": 7, "maxzoom": 9, "quadkey_zoom": 7, "bounds": [-75.98703377413767, 44.94205659982972, -72.90811027838137, 47.09314422696482], "center": [-74.44757202625952, 46.01760041339727, 7], "tiles": {"0302300": ["tests/fixtures/cog1.tif"], "0302301": ["tests/fixtures/cog1.tif"], "0302310": ["tests/fixtures/cog1.tif"], "0302302": ["tests/fixtures/cog1.tif"], "0302303": ["tests/fixtures/cog1.tif"], "0302312": ["tests/fixtures/cog1.tif"], "0302320": ["tests/fixtures/cog1.tif"], "0302321": ["tests/fixtures/cog1.tif"], "0302330": ["tests/fixtures/cog1.tif"]}}
``` 