### PR TITLE
Update mosaic

### DIFF
--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -1,6 +1,6 @@
 """cogeo_mosaic.backend.base: base Backend class."""
 
-from typing import Any, Callable, Dict, List, Sequence
+from typing import Callable, Dict, List, Sequence
 
 import abc
 from contextlib import AbstractContextManager
@@ -17,6 +17,7 @@ from cogeo_mosaic.backends.utils import get_hash
 class BaseBackend(AbstractContextManager):
     """Base Class for cogeo-mosaic backend storage."""
 
+    path: str
     mosaic_def: MosaicJSON
 
     @abc.abstractmethod
@@ -66,16 +67,6 @@ class BaseBackend(AbstractContextManager):
     def write(self):
         """Upload new MosaicJSON to backend."""
 
-    @abc.abstractmethod
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any,
-    ):
-        """Update existing MosaicJSON on backend."""
-
     def _update_quadkey(self, quadkey: str, dataset: List[str]):
         """Update quadkey list."""
         self.mosaic_def.tiles[quadkey] = dataset
@@ -90,10 +81,10 @@ class BaseBackend(AbstractContextManager):
             self.mosaic_def.minzoom,
         )
 
-    def _update(
+    def update(
         self,
         features: Sequence[Dict],
-        accessor: Callable,
+        accessor: Callable = DEFAULT_ACCESSOR,
         add_first: bool = True,
         **kwargs,
     ):
@@ -146,4 +137,6 @@ class BaseBackend(AbstractContextManager):
         )
         self._update_metadata(bounds, version)
 
+        if self.path:
+            self.write()
         return

--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -77,19 +77,13 @@ class BaseBackend(AbstractContextManager):
             self.mosaic_def.minzoom,
         )
 
-    def update(
-        self,
-        features: Sequence[Dict],
-        add_first: bool = True,
-        mosaic_class=MosaicJSON,
-        **kwargs,
-    ):
+    def update(self, features: Sequence[Dict], add_first: bool = True, **kwargs):
         """Update existing MosaicJSON on backend."""
         version = list(map(int, self.mosaic_def.version.split(".")))
         version[-1] += 1
-        version = ".".join(map(str, version))
+        new_version = ".".join(map(str, version))
 
-        new_mosaic = mosaic_class.from_features(
+        new_mosaic = self.mosaic_def.from_features(
             features,
             self.mosaic_def.minzoom,
             self.mosaic_def.maxzoom,
@@ -112,7 +106,7 @@ class BaseBackend(AbstractContextManager):
             max(nxmax, oxmax),
             max(nymax, oymax),
         ]
-        self._update_metadata(bounds, version)
+        self._update_metadata(bounds, new_version)
 
         # We only write if path is set
         if self.path:

--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -1,10 +1,15 @@
 """cogeo_mosaic.backend.base: base Backend class."""
 
-from typing import Dict, List
+from typing import Callable, Dict, List, Sequence
 
 import abc
 from contextlib import AbstractContextManager
 
+import mercantile
+from pygeos import STRtree, polygons
+from supermercado import burntiles
+
+from cogeo_mosaic.utils import tiles_to_bounds
 from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.utils import get_hash
 
@@ -64,3 +69,83 @@ class BaseBackend(AbstractContextManager):
     @abc.abstractmethod
     def update(self):
         """Update existing MosaicJSON on backend."""
+
+    def _update_quadkey(self, quadkey: str, dataset: List[str]):
+        """Update quadkey list."""
+        self.mosaic_def.tiles[quadkey] = dataset
+
+    def _update_metadata(self, bounds: List[float], version: str):
+        """Update bounds and center."""
+        self.mosaic_def.version = version
+        self.mosaic_def.bounds = bounds
+        self.mosaic_def.center = (
+            (bounds[0] + bounds[2]) / 2,
+            (bounds[1] + bounds[3]) / 2,
+            self.mosaic_def.minzoom,
+        )
+
+    def _update(
+        self,
+        features: Sequence[Dict],
+        accessor: Callable,
+        on_top: bool = True,
+        **kwargs
+    ):
+        """Update existing MosaicJSON on backend."""
+        version = self.mosaic_def.version
+        if version:
+            uversion = list(map(int, version.split(".")))
+            uversion[-1] += 1
+            version = ".".join(map(str, uversion))
+        else:
+            version = "1.0.0"
+
+        updated_quadkeys = set()
+
+        dataset_geoms = polygons(
+            [feat["geometry"]["coordinates"][0] for feat in features]
+        )
+
+        for idx, feature in enumerate(features):
+            tiles = burntiles.burn([feature], self.quadkey_zoom)
+            tiles = [mercantile.Tile(*tile) for tile in tiles]
+
+            tree = STRtree([dataset_geoms[idx]])
+
+            for tile in tiles:
+                quadkey = str(mercantile.quadkey(tile))
+                tile_geom = polygons(
+                    mercantile.feature(tile)["geometry"]["coordinates"][0]
+                )
+
+                # Find intersections from rtree
+                intersections_idx = sorted(
+                    tree.query(tile_geom, predicate="intersects")
+                )
+                if len(intersections_idx) == 0:
+                    continue
+
+                intersect_dataset, intersect_geoms = zip(
+                    *[(features[idx], dataset_geoms[idx]) for idx in intersections_idx]
+                )
+
+                dataset = self.mosaic_def._filter(
+                    tile, intersect_dataset, intersect_geoms, **kwargs
+                )
+                new_assets = [accessor(f) for f in dataset]
+
+                assets = self.tile(*tile)
+                assets = [*new_assets, *assets] if on_top else [*assets, *new_assets]
+                self._update_quadkey(quadkey, assets)
+
+                updated_quadkeys.add(tile)
+        bounds = self.mosaic_def.bounds
+        minimumTile = mercantile.tile(bounds[0], bounds[3], self.quadkey_zoom)
+        maximumTile = mercantile.tile(bounds[2], bounds[1], self.quadkey_zoom)
+        bounds = tiles_to_bounds(
+            [t for t in updated_quadkeys] + [minimumTile, maximumTile]
+        )
+
+        self._update_metadata(bounds, version)
+
+        return

--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -113,12 +113,11 @@ class BaseBackend(AbstractContextManager):
             tree = STRtree([dataset_geoms[idx]])
 
             for tile in tiles:
-                quadkey = str(mercantile.quadkey(tile))
+                quadkey = mercantile.quadkey(tile)
                 tile_geom = polygons(
                     mercantile.feature(tile)["geometry"]["coordinates"][0]
                 )
 
-                # Find intersections from rtree
                 intersections_idx = sorted(
                     tree.query(tile_geom, predicate="intersects")
                 )
@@ -139,13 +138,13 @@ class BaseBackend(AbstractContextManager):
                 self._update_quadkey(quadkey, assets)
 
                 updated_quadkeys.add(tile)
+
         bounds = self.mosaic_def.bounds
         minimumTile = mercantile.tile(bounds[0], bounds[3], self.quadkey_zoom)
         maximumTile = mercantile.tile(bounds[2], bounds[1], self.quadkey_zoom)
         bounds = tiles_to_bounds(
             [t for t in updated_quadkeys] + [minimumTile, maximumTile]
         )
-
         self._update_metadata(bounds, version)
 
         return

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -1,6 +1,6 @@
 """cogeo-mosaic AWS DynamoDB backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import functools
 import itertools
@@ -15,7 +15,7 @@ import mercantile
 
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import find_quadkeys
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 
 
 class DynamoDBBackend(BaseBackend):
@@ -31,6 +31,7 @@ class DynamoDBBackend(BaseBackend):
         """Initialize DynamoDBBackend."""
         self.client = client or boto3.resource("dynamodb", region_name=region)
         self.table = self.client.Table(table_name)
+        self.path = f"dynamodb://{region}/{table_name}"
 
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
@@ -68,19 +69,6 @@ class DynamoDBBackend(BaseBackend):
         meta = json.loads(json.dumps(self.metadata), parse_float=Decimal)
         meta["quadkey"] = "-1"
         self.table.put_item(Item=meta)
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = True,
-        **kwargs: Any
-    ):
-        """Update the mosaicjson document."""
-        if not overwrite:
-            raise Exception("Overwrite has to be set to True")
-
-        self._update(features, accessor, **kwargs)
 
     def _create_table(self, billing_mode: str = "PAY_PER_REQUEST"):
         # Define schema for primary key

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -15,7 +15,7 @@ import mercantile
 
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import find_quadkeys
-from cogeo_mosaic.mosaic import MosaicJSON
+from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
 
 
 class DynamoDBBackend(BaseBackend):
@@ -58,22 +58,22 @@ class DynamoDBBackend(BaseBackend):
 
     def _update_metadata(self, bounds: List[float], version: str):
         """Update bounds and center."""
-        meta = json.loads(json.dumps(self.metadata), parse_float=Decimal)
-        meta["version"] = version
-        meta["bounds"] = bounds
-        meta["center"] = (
+        self.mosaic_def.bounds = bounds
+        self.mosaic_def.center = (
             (bounds[0] + bounds[2]) / 2,
             (bounds[1] + bounds[3]) / 2,
             self.mosaic_def.minzoom,
         )
-        meta["quadkey"] == "-1"
+        self.mosaic_def.version = version
+        meta = json.loads(json.dumps(self.metadata), parse_float=Decimal)
+        meta["quadkey"] = "-1"
         self.table.put_item(Item=meta)
 
     def update(
         self,
         features: Sequence[Dict],
-        accessor: Callable,
-        overwrite: bool = False,
+        accessor: Callable = DEFAULT_ACCESSOR,
+        overwrite: bool = True,
         **kwargs: Any
     ):
         """Update the mosaicjson document."""

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -1,6 +1,6 @@
 """cogeo-mosaic File backend."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import json
 import functools
@@ -53,9 +53,17 @@ class FileBackend(BaseBackend):
             else:
                 f.write(json.dumps(body).encode("utf-8"))
 
-    def update(self):
+    def update(
+        self,
+        features: Sequence[Dict],
+        accessor: Callable,
+        overwrite: bool = False,
+        **kwargs: Any
+    ):
         """Update the mosaicjson document."""
-        raise NotImplementedError
+        self._update(features, accessor, **kwargs)
+        if overwrite:
+            self.write()
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -7,7 +7,7 @@ import functools
 
 import mercantile
 
-from cogeo_mosaic.mosaic import MosaicJSON
+from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import (
     _compress_gz_json,
@@ -23,7 +23,7 @@ class FileBackend(BaseBackend):
         self,
         path: str,
         mosaic_def: Optional[Union[MosaicJSON, Dict]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         """Initialize FileBackend."""
         self.path = path
@@ -56,9 +56,9 @@ class FileBackend(BaseBackend):
     def update(
         self,
         features: Sequence[Dict],
-        accessor: Callable,
+        accessor: Callable = DEFAULT_ACCESSOR,
         overwrite: bool = False,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         """Update the mosaicjson document."""
         self._update(features, accessor, **kwargs)

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -1,13 +1,13 @@
 """cogeo-mosaic File backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import json
 import functools
 
 import mercantile
 
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import (
     _compress_gz_json,
@@ -52,18 +52,6 @@ class FileBackend(BaseBackend):
                 f.write(_compress_gz_json(body))
             else:
                 f.write(json.dumps(body).encode("utf-8"))
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any,
-    ):
-        """Update the mosaicjson document."""
-        self._update(features, accessor, **kwargs)
-        if overwrite:
-            self.write()
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/cogeo_mosaic/backends/http.py
+++ b/cogeo_mosaic/backends/http.py
@@ -1,8 +1,9 @@
 """cogeo-mosaic HTTP backend."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import json
+import warnings
 import functools
 
 import requests
@@ -45,9 +46,17 @@ class HttpBackend(BaseBackend):
         """Write mosaicjson document."""
         raise NotImplementedError
 
-    def update(self):
+    def update(
+        self,
+        features: Sequence[Dict],
+        accessor: Callable,
+        overwrite: bool = False,
+        **kwargs: Any
+    ):
         """Update the mosaicjson document."""
-        raise NotImplementedError
+        self._update(features, accessor, **kwargs)
+        if overwrite:
+            warnings.warn("Overwrite is not possible for http backend")
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/cogeo_mosaic/backends/http.py
+++ b/cogeo_mosaic/backends/http.py
@@ -1,15 +1,14 @@
 """cogeo-mosaic HTTP backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import json
-import warnings
 import functools
 
 import requests
 import mercantile
 
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import _decompress_gz, get_assets_from_json
 
@@ -24,7 +23,7 @@ class HttpBackend(BaseBackend):
         **kwargs: Any
     ):
         """Initialize HttpBackend."""
-        self.url = url
+        self.path = url
 
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
@@ -46,24 +45,16 @@ class HttpBackend(BaseBackend):
         """Write mosaicjson document."""
         raise NotImplementedError
 
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any
-    ):
+    def update(self, *args, **kwargs: Any):
         """Update the mosaicjson document."""
-        self._update(features, accessor, **kwargs)
-        if overwrite:
-            warnings.warn("Overwrite is not possible for http backend")
+        raise NotImplementedError
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:
         """Get mosaicjson document."""
-        body = requests.get(self.url).content
+        body = requests.get(self.path).content
 
-        if gzip or (gzip is None and self.url.endswith(".gz")):
+        if gzip or (gzip is None and self.path.endswith(".gz")):
             body = _decompress_gz(body)
 
         return MosaicJSON(**json.loads(body))

--- a/cogeo_mosaic/backends/http.py
+++ b/cogeo_mosaic/backends/http.py
@@ -9,7 +9,7 @@ import functools
 import requests
 import mercantile
 
-from cogeo_mosaic.mosaic import MosaicJSON
+from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import _decompress_gz, get_assets_from_json
 
@@ -49,7 +49,7 @@ class HttpBackend(BaseBackend):
     def update(
         self,
         features: Sequence[Dict],
-        accessor: Callable,
+        accessor: Callable = DEFAULT_ACCESSOR,
         overwrite: bool = False,
         **kwargs: Any
     ):

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -1,6 +1,6 @@
 """cogeo-mosaic AWS S3 backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import json
 import functools
@@ -9,7 +9,7 @@ import mercantile
 
 from boto3.session import Session as boto3_session
 
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import (
     _compress_gz_json,
@@ -27,12 +27,13 @@ class S3Backend(BaseBackend):
         key: str,
         mosaic_def: Optional[Union[MosaicJSON, Dict]] = None,
         client: Optional[boto3_session.client] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         """Initialize S3Backend."""
         self.client = client or boto3_session().client("s3")
         self.key = key
         self.bucket = bucket
+        self.path = f"s3://{bucket}/{key}"
 
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
@@ -59,18 +60,6 @@ class S3Backend(BaseBackend):
             body = json.dumps(body).encode("utf-8")
 
         _aws_put_data(self.key, self.bucket, body, client=self.client, **kwargs)
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any
-    ):
-        """Update the mosaicjson document."""
-        self._update(features, accessor, **kwargs)
-        if overwrite:
-            self.write()
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -1,6 +1,6 @@
 """cogeo-mosaic AWS S3 backend."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Union
 
 import json
 import functools
@@ -60,9 +60,17 @@ class S3Backend(BaseBackend):
 
         _aws_put_data(self.key, self.bucket, body, client=self.client, **kwargs)
 
-    def update(self):
+    def update(
+        self,
+        features: Sequence[Dict],
+        accessor: Callable,
+        overwrite: bool = False,
+        **kwargs: Any
+    ):
         """Update the mosaicjson document."""
-        raise NotImplementedError
+        self._update(features, accessor, **kwargs)
+        if overwrite:
+            self.write()
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -9,7 +9,7 @@ import mercantile
 
 from boto3.session import Session as boto3_session
 
-from cogeo_mosaic.mosaic import MosaicJSON
+from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import (
     _compress_gz_json,
@@ -63,7 +63,7 @@ class S3Backend(BaseBackend):
     def update(
         self,
         features: Sequence[Dict],
-        accessor: Callable,
+        accessor: Callable = DEFAULT_ACCESSOR,
         overwrite: bool = False,
         **kwargs: Any
     ):

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -1,6 +1,6 @@
 """cogeo_mosaic.mosaic MosaicJSON models and helper functions."""
 
-from typing import Callable, Dict, List, Optional, Tuple, Sequence
+from typing import Any, Callable, Dict, List, Optional, Tuple, Sequence
 
 import warnings
 
@@ -129,13 +129,13 @@ class MosaicJSON(BaseModel):
         tiles = burntiles.burn(features, quadkey_zoom)
         tiles = [mercantile.Tile(*tile) for tile in tiles]
 
-        mosaic_definition = dict(
+        mosaic_definition: Dict[str, Any] = dict(
             mosaicjson=version,
             minzoom=minzoom,
             maxzoom=maxzoom,
             quadkey_zoom=quadkey_zoom,
             bounds=bounds,
-            center=[(bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2, minzoom],
+            center=((bounds[0] + bounds[2]) / 2, (bounds[1] + bounds[3]) / 2, minzoom),
             tiles={},
             version="1.0.0",
         )

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -37,6 +37,11 @@ class MosaicJSON(BaseModel):
     center: Optional[Tuple[float, float, int]]
     tiles: Dict[str, List[str]]
 
+    class Config:
+        """Validate model on update."""
+
+        validate_asignment = True
+
     @classmethod
     def _filter(
         cls,

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -14,7 +14,37 @@ from cogeo_mosaic.utils import get_footprints, _intersect_percent
 from pydantic import BaseModel, Field
 
 
-DEFAULT_ACCESSOR: Callable = lambda feature: feature["properties"]["path"]
+def default_accessor(feature: Dict):
+    """Return specific feature identifier."""
+    return feature["properties"]["path"]
+
+
+def default_filter(
+    tile: mercantile.Tile,
+    dataset: Sequence[Dict],
+    geoms: Sequence[polygons],
+    minimum_tile_cover=None,
+    tile_cover_sort=False,
+    maximum_items_per_tile: Optional[int] = None,
+) -> List:
+    """Filter and/or sort dataset per intersection coverage."""
+    indices = list(range(len(dataset)))
+
+    if minimum_tile_cover or tile_cover_sort:
+        tile_geom = polygons(mercantile.feature(tile)["geometry"]["coordinates"][0])
+        int_pcts = _intersect_percent(tile_geom, geoms)
+
+        if minimum_tile_cover:
+            indices = [ind for ind in indices if int_pcts[ind] > minimum_tile_cover]
+
+        if tile_cover_sort:
+            # https://stackoverflow.com/a/9764364
+            indices, _ = zip(*sorted(zip(indices, int_pcts), reverse=True))
+
+    if maximum_items_per_tile:
+        indices = indices[:maximum_items_per_tile]
+
+    return [dataset[ind] for ind in indices]
 
 
 class MosaicJSON(BaseModel):
@@ -43,42 +73,14 @@ class MosaicJSON(BaseModel):
         validate_asignment = True
 
     @classmethod
-    def _filter(
-        cls,
-        tile: mercantile.Tile,
-        dataset: Sequence[Dict],
-        geoms: Sequence[polygons],
-        minimum_tile_cover=None,
-        tile_cover_sort=False,
-        maximum_items_per_tile: Optional[int] = None,
-    ) -> List:
-        """Filter and/or sort dataset per intersection coverage."""
-        indices = list(range(len(dataset)))
-
-        if minimum_tile_cover or tile_cover_sort:
-            tile_geom = polygons(mercantile.feature(tile)["geometry"]["coordinates"][0])
-            int_pcts = _intersect_percent(tile_geom, geoms)
-
-            if minimum_tile_cover:
-                indices = [ind for ind in indices if int_pcts[ind] > minimum_tile_cover]
-
-            if tile_cover_sort:
-                # https://stackoverflow.com/a/9764364
-                indices, _ = zip(*sorted(zip(indices, int_pcts), reverse=True))
-
-        if maximum_items_per_tile:
-            indices = indices[:maximum_items_per_tile]
-
-        return [dataset[ind] for ind in indices]
-
-    @classmethod
     def _create_mosaic(
         cls,
         features: Sequence[Dict],
         minzoom: int,
         maxzoom: int,
         quadkey_zoom: Optional[int] = None,
-        accessor: Callable[[Dict], str] = DEFAULT_ACCESSOR,
+        accessor: Callable[[Dict], str] = default_accessor,
+        asset_filter: Callable = default_filter,
         version: str = "0.0.2",
         quiet: bool = True,
         **kwargs,
@@ -97,13 +99,15 @@ class MosaicJSON(BaseModel):
         quadkey_zoom: int, optional
             Force mosaic quadkey zoom.
         accessor: callable, required
-            Function called on each feature to get its identifier (default is feature["properties"]["path"])
+            Function called on each feature to get its identifier (default is feature["properties"]["path"]).
+        asset_filter: callable, required
+            Function to filter features.
         version: str, optional
             mosaicJSON definition version (default: 0.0.2).
         quiet: bool, optional (default: True)
             Mask processing steps.
         kwargs: any
-            Options forwarded to MosaicJSON._filter
+            Options forwarded to `asset_filter`
 
         Returns
         -------
@@ -155,7 +159,7 @@ class MosaicJSON(BaseModel):
                 *[(features[idx], dataset_geoms[idx]) for idx in intersections_idx]
             )
 
-            dataset = cls._filter(tile, intersect_dataset, intersect_geoms, **kwargs)
+            dataset = asset_filter(tile, intersect_dataset, intersect_geoms, **kwargs)
 
             if dataset:
                 mosaic_definition["tiles"][quadkey] = [accessor(f) for f in dataset]

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -138,7 +138,7 @@ class MosaicJSON(BaseModel):
         tree = STRtree(dataset_geoms)
 
         for tile in tiles:
-            quadkey = str(mercantile.quadkey(tile))
+            quadkey = mercantile.quadkey(tile)
             tile_geom = polygons(mercantile.feature(tile)["geometry"]["coordinates"][0])
 
             # Find intersections from rtree

--- a/cogeo_mosaic/mosaic.py
+++ b/cogeo_mosaic/mosaic.py
@@ -46,7 +46,7 @@ class MosaicJSON(BaseModel):
         minimum_tile_cover=None,
         tile_cover_sort=False,
         maximum_items_per_tile: Optional[int] = None,
-    ):
+    ) -> List:
         """Filter and/or sort dataset per intersection coverage."""
         indices = list(range(len(dataset)))
 
@@ -138,7 +138,7 @@ class MosaicJSON(BaseModel):
         tree = STRtree(dataset_geoms)
 
         for tile in tiles:
-            quadkey = mercantile.quadkey(tile)
+            quadkey = str(mercantile.quadkey(tile))
             tile_geom = polygons(mercantile.feature(tile)["geometry"]["coordinates"][0])
 
             # Find intersections from rtree

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -163,13 +163,24 @@ def create_from_features(
     default=lambda: os.environ.get("MAX_THREADS", multiprocessing.cpu_count() * 5),
     help="threads",
 )
-def update(input_files, input_mosaic, min_tile_cover, add_first, threads):
+@click.option(
+    "--quiet",
+    "-q",
+    help="Remove progressbar and other non-error output.",
+    is_flag=True,
+    default=False,
+)
+def update(input_files, input_mosaic, min_tile_cover, add_first, threads, quiet):
     """Update mosaic definition file."""
     input_files = input_files.read().splitlines()
     features = get_footprints(input_files, max_threads=threads)
-
     with MosaicBackend(input_mosaic) as mosaic:
-        mosaic.update(features, add_first=add_first, minimum_tile_cover=min_tile_cover)
+        mosaic.update(
+            features,
+            add_first=add_first,
+            minimum_tile_cover=min_tile_cover,
+            quiet=quiet,
+        )
 
 
 @cogeo_cli.command(short_help="Create geojson from list of files")

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -152,8 +152,8 @@ def create_from_features(
 @click.argument("input_mosaic", type=click.Path())
 @click.option("--min-tile-cover", type=float, help="Minimum % overlap")
 @click.option(
-    "--on-top/--on-bottom",
-    help="happens dataset on top of the existing scenes.",
+    "--add-first/--add-last",
+    help="Happens dataset on top of the existing scenes.",
     is_flag=True,
     default=True,
 )
@@ -164,7 +164,7 @@ def create_from_features(
     default=lambda: os.environ.get("MAX_THREADS", multiprocessing.cpu_count() * 5),
     help="threads",
 )
-def update(input_files, input_mosaic, min_tile_cover, on_top, overwrite, threads):
+def update(input_files, input_mosaic, min_tile_cover, add_first, overwrite, threads):
     """Update mosaic definition file."""
     if input_mosaic.startswith("dynamodb://") and not overwrite:
         raise Exception(
@@ -178,7 +178,7 @@ def update(input_files, input_mosaic, min_tile_cover, on_top, overwrite, threads
         mosaic.update(
             features,
             DEFAULT_ACCESSOR,
-            on_top=on_top,
+            add_first=add_first,
             overwrite=overwrite,
             minimum_tile_cover=min_tile_cover,
         )

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -153,7 +153,7 @@ def create_from_features(
 @click.option("--min-tile-cover", type=float, help="Minimum % overlap")
 @click.option(
     "--add-first/--add-last",
-    help="Happens dataset on top of the existing scenes.",
+    help="Appends dataset on top of the existing scenes.",
     is_flag=True,
     default=True,
 )

--- a/cogeo_mosaic/utils.py
+++ b/cogeo_mosaic/utils.py
@@ -110,7 +110,7 @@ def get_footprints(
     return list(_filter_futures(future_work))
 
 
-def tiles_to_bounds(tiles):
+def tiles_to_bounds(tiles: List[mercantile.Tile]) -> List[float]:
     """Get bounds from a set of mercator tiles."""
     zoom = tiles[0].z
     xyz = numpy.array([[t.x, t.y, t.z] for t in tiles])

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -76,9 +76,9 @@ def test_file_backend():
             "center",
         ]
 
-    with pytest.raises(NotImplementedError):
-        with MosaicBackend(mosaic_json) as mosaic:
-            mosaic.update()
+    # with pytest.raises(NotImplementedError):
+    #     with MosaicBackend(mosaic_json) as mosaic:
+    #         mosaic.update()
 
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -141,11 +141,11 @@ def test_http_backend(requests):
     with open(mosaic_json, "r") as f:
         requests.get.return_value = MockResponse(f.read())
 
-    with pytest.raises(NotImplementedError):
-        with MosaicBackend("https://mymosaic.json") as mosaic:
-            mosaic.update()
-        requests.get.assert_called_once()
-        requests.mock_reset()
+    # with pytest.raises(NotImplementedError):
+    #     with MosaicBackend("https://mymosaic.json") as mosaic:
+    #         mosaic.update()
+    #     requests.get.assert_called_once()
+    #     requests.mock_reset()
 
     with pytest.raises(NotImplementedError):
         with MosaicBackend(
@@ -205,15 +205,15 @@ def test_s3_backend(session):
         }
     session.return_value.client.return_value.put_object.return_value = True
 
-    with pytest.raises(NotImplementedError):
-        with MosaicBackend("s3://mybucket/mymosaic.json.gz") as mosaic:
-            assert isinstance(mosaic, S3Backend)
-            mosaic.update()
-    session.return_value.client.return_value.get_object.assert_called_once_with(
-        Bucket="mybucket", Key="mymosaic.json.gz"
-    )
-    session.return_value.client.return_value.put_object.assert_not_called()
-    session.reset_mock()
+    # with pytest.raises(NotImplementedError):
+    #     with MosaicBackend("s3://mybucket/mymosaic.json.gz") as mosaic:
+    #         assert isinstance(mosaic, S3Backend)
+    #         mosaic.update()
+    # session.return_value.client.return_value.get_object.assert_called_once_with(
+    #     Bucket="mybucket", Key="mymosaic.json.gz"
+    # )
+    # session.return_value.client.return_value.put_object.assert_not_called()
+    # session.reset_mock()
 
     with MosaicBackend(
         "s3://mybucket/mymosaic.json.gz", mosaic_def=mosaic_content
@@ -315,12 +315,12 @@ def test_dynamoDB_backend(client):
         assert mosaic.tile(150, 182, 9) == ["cog1.tif", "cog2.tif"]
         assert mosaic.point(-73, 45) == ["cog1.tif", "cog2.tif"]
 
-    with pytest.raises(NotImplementedError):
-        with MosaicBackend(
-            "dynamodb:///thiswaskylebarronidea", mosaic_def=mosaic_content
-        ) as mosaic:
-            assert isinstance(mosaic, DynamoDBBackend)
-            mosaic.update()
+    # with pytest.raises(NotImplementedError):
+    #     with MosaicBackend(
+    #         "dynamodb:///thiswaskylebarronidea", mosaic_def=mosaic_content
+    #     ) as mosaic:
+    #         assert isinstance(mosaic, DynamoDBBackend)
+    #         mosaic.update()
 
     with MosaicBackend(
         "dynamodb:///thiswaskylebarronidea", mosaic_def=mosaic_content

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -76,10 +76,6 @@ def test_file_backend():
             "center",
         ]
 
-    # with pytest.raises(NotImplementedError):
-    #     with MosaicBackend(mosaic_json) as mosaic:
-    #         mosaic.update()
-
     runner = CliRunner()
     with runner.isolated_filesystem():
         with MosaicBackend("mosaic.json", mosaic_def=mosaic_content) as mosaic:
@@ -141,11 +137,11 @@ def test_http_backend(requests):
     with open(mosaic_json, "r") as f:
         requests.get.return_value = MockResponse(f.read())
 
-    # with pytest.raises(NotImplementedError):
-    #     with MosaicBackend("https://mymosaic.json") as mosaic:
-    #         mosaic.update()
-    #     requests.get.assert_called_once()
-    #     requests.mock_reset()
+    with pytest.raises(NotImplementedError):
+        with MosaicBackend("https://mymosaic.json") as mosaic:
+            mosaic.update()
+        requests.get.assert_called_once()
+        requests.mock_reset()
 
     with pytest.raises(NotImplementedError):
         with MosaicBackend(
@@ -204,16 +200,6 @@ def test_s3_backend(session):
             "Body": BytesIO(f.read())
         }
     session.return_value.client.return_value.put_object.return_value = True
-
-    # with pytest.raises(NotImplementedError):
-    #     with MosaicBackend("s3://mybucket/mymosaic.json.gz") as mosaic:
-    #         assert isinstance(mosaic, S3Backend)
-    #         mosaic.update()
-    # session.return_value.client.return_value.get_object.assert_called_once_with(
-    #     Bucket="mybucket", Key="mymosaic.json.gz"
-    # )
-    # session.return_value.client.return_value.put_object.assert_not_called()
-    # session.reset_mock()
 
     with MosaicBackend(
         "s3://mybucket/mymosaic.json.gz", mosaic_def=mosaic_content
@@ -314,13 +300,6 @@ def test_dynamoDB_backend(client):
         ]
         assert mosaic.tile(150, 182, 9) == ["cog1.tif", "cog2.tif"]
         assert mosaic.point(-73, 45) == ["cog1.tif", "cog2.tif"]
-
-    # with pytest.raises(NotImplementedError):
-    #     with MosaicBackend(
-    #         "dynamodb:///thiswaskylebarronidea", mosaic_def=mosaic_content
-    #     ) as mosaic:
-    #         assert isinstance(mosaic, DynamoDBBackend)
-    #         mosaic.update()
 
     with MosaicBackend(
         "dynamodb:///thiswaskylebarronidea", mosaic_def=mosaic_content

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,15 @@ def test_update_valid():
             f.write("\n".join([asset2]))
 
         result = runner.invoke(cogeo_cli, ["update", "list.txt", "mosaic.json"])
+        assert not result.exception
+        assert result.exit_code == 0
+        updated_mosaic = json.loads(result.output)
+        updated_mosaic["version"] == "1.0.1"
+        assert not mosaic_content.tiles == updated_mosaic["tiles"]
 
+        result = runner.invoke(
+            cogeo_cli, ["update", "list.txt", "mosaic.json", "--on-bottom"]
+        )
         assert not result.exception
         assert result.exit_code == 0
         updated_mosaic = json.loads(result.output)
@@ -53,11 +61,12 @@ def test_update_valid():
         assert mosaic_content.tiles == updated_mosaic["tiles"]
 
         result = runner.invoke(
-            cogeo_cli, ["update", "list.txt", "mosaic.json", "-o", "mosaicU.json"]
+            cogeo_cli,
+            ["update", "list.txt", "mosaic.json", "--overwrite", "--on-bottom"],
         )
         assert not result.exception
         assert result.exit_code == 0
-        with open("mosaicU.json", "r") as f:
+        with open("mosaic.json", "r") as f:
             updated_mosaic = json.load(f)
             updated_mosaic["version"] == "1.0.1"
             assert mosaic_content.tiles == updated_mosaic["tiles"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,22 +47,16 @@ def test_update_valid():
         result = runner.invoke(cogeo_cli, ["update", "list.txt", "mosaic.json"])
         assert not result.exception
         assert result.exit_code == 0
-        updated_mosaic = json.loads(result.output)
-        updated_mosaic["version"] == "1.0.1"
-        assert not mosaic_content.tiles == updated_mosaic["tiles"]
+        with open("mosaic.json", "r") as f:
+            updated_mosaic = json.load(f)
+            updated_mosaic["version"] == "1.0.1"
+            assert not mosaic_content.tiles == updated_mosaic["tiles"]
+
+        with open("mosaic.json", "w") as f:
+            f.write(json.dumps(MosaicJSON.from_urls([asset1]).dict(exclude_none=True)))
 
         result = runner.invoke(
             cogeo_cli, ["update", "list.txt", "mosaic.json", "--add-last"]
-        )
-        assert not result.exception
-        assert result.exit_code == 0
-        updated_mosaic = json.loads(result.output)
-        updated_mosaic["version"] == "1.0.1"
-        assert mosaic_content.tiles == updated_mosaic["tiles"]
-
-        result = runner.invoke(
-            cogeo_cli,
-            ["update", "list.txt", "mosaic.json", "--overwrite", "--add-last"],
         )
         assert not result.exception
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,7 +44,9 @@ def test_update_valid():
         with open("./list.txt", "w") as f:
             f.write("\n".join([asset2]))
 
-        result = runner.invoke(cogeo_cli, ["update", "list.txt", "mosaic.json"])
+        result = runner.invoke(
+            cogeo_cli, ["update", "list.txt", "mosaic.json", "--quiet"]
+        )
         assert not result.exception
         assert result.exit_code == 0
         with open("mosaic.json", "r") as f:
@@ -56,7 +58,7 @@ def test_update_valid():
             f.write(json.dumps(MosaicJSON.from_urls([asset1]).dict(exclude_none=True)))
 
         result = runner.invoke(
-            cogeo_cli, ["update", "list.txt", "mosaic.json", "--add-last"]
+            cogeo_cli, ["update", "list.txt", "mosaic.json", "--add-last", "--quiet"]
         )
         assert not result.exception
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -52,7 +52,7 @@ def test_update_valid():
         assert not mosaic_content.tiles == updated_mosaic["tiles"]
 
         result = runner.invoke(
-            cogeo_cli, ["update", "list.txt", "mosaic.json", "--on-bottom"]
+            cogeo_cli, ["update", "list.txt", "mosaic.json", "--add-last"]
         )
         assert not result.exception
         assert result.exit_code == 0
@@ -62,7 +62,7 @@ def test_update_valid():
 
         result = runner.invoke(
             cogeo_cli,
-            ["update", "list.txt", "mosaic.json", "--overwrite", "--on-bottom"],
+            ["update", "list.txt", "mosaic.json", "--overwrite", "--add-last"],
         )
         assert not result.exception
         assert result.exit_code == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,6 @@ import mercantile
 import pytest
 
 from cogeo_mosaic import utils
-from cogeo_mosaic.mosaic import MosaicJSON
 
 asset1 = os.path.join(os.path.dirname(__file__), "fixtures", "cog1.tif")
 asset2 = os.path.join(os.path.dirname(__file__), "fixtures", "cog2.tif")
@@ -53,22 +52,3 @@ def test_tiles_to_bounds():
     """Get tiles bounds for zoom level."""
     tiles = [mercantile.Tile(x=150, y=182, z=9), mercantile.Tile(x=151, y=182, z=9)]
     assert len(utils.tiles_to_bounds(tiles)) == 4
-
-
-def test_update_mosaic():
-    """Create mosaic and update it."""
-    mosaic = MosaicJSON.from_urls([asset1], minzoom=9).dict(exclude_none=True)
-    assert len(mosaic["tiles"]) == 36
-
-    mosaic = MosaicJSON.from_urls([asset1], minzoom=9).dict(exclude_none=True)
-    assert mosaic["version"] == "1.0.0"
-    utils.update_mosaic([asset2], mosaic)
-
-    assert len(mosaic["tiles"]) == 48
-    assert len(mosaic["tiles"]["030230132"]) == 2
-    assert mosaic["version"] == "1.0.1"
-
-    mosaic = MosaicJSON.from_urls([asset1], minzoom=9).dict(exclude_none=True)
-    utils.update_mosaic([asset2], mosaic, minimum_tile_cover=0.1)
-    assert len(mosaic["tiles"]) == 47
-    assert len(mosaic["tiles"]["030230132"]) == 1


### PR DESCRIPTION
This PR aims to add the `update` method for all backends. 

To be able to handler update for different backends and by maximizing code re-use I had to add 2 privates methods in the base class: 
- `_update_quadkey`: update quadkey dataset
- `_update_metadata`: update bounds, center and version metadata

TBD: the `update` method introduces a new `concept` with the `on_top` option. This is basically to let the user happens the new data on top or on the bottom of the dataset list. 

The problem with this `on_top` and with looping through the datafeatures, is that when a user will pass a list (e.g `1.tiff, 2.tiff`) with `on_top` we will end up with `[2.tif, 1.tif, alreadyinlist.tif]` so we might want to reverse the order of the input list when `on_top=True`. This feature will also need more documentation 

cc @kylebarron @geospatial-jeff 
