### PR TITLE
remove http update method

### DIFF
--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -1,6 +1,6 @@
 """cogeo_mosaic.backend.base: base Backend class."""
 
-from typing import Any, Callable, Dict, List, Sequence
+from typing import Callable, Dict, List, Sequence
 
 import abc
 from contextlib import AbstractContextManager
@@ -17,6 +17,7 @@ from cogeo_mosaic.backends.utils import get_hash
 class BaseBackend(AbstractContextManager):
     """Base Class for cogeo-mosaic backend storage."""
 
+    path: str
     mosaic_def: MosaicJSON
 
     @abc.abstractmethod
@@ -66,16 +67,6 @@ class BaseBackend(AbstractContextManager):
     def write(self):
         """Upload new MosaicJSON to backend."""
 
-    @abc.abstractmethod
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any,
-    ):
-        """Update existing MosaicJSON on backend."""
-
     def _update_quadkey(self, quadkey: str, dataset: List[str]):
         """Update quadkey list."""
         self.mosaic_def.tiles[quadkey] = dataset
@@ -90,10 +81,10 @@ class BaseBackend(AbstractContextManager):
             self.mosaic_def.minzoom,
         )
 
-    def _update(
+    def update(
         self,
         features: Sequence[Dict],
-        accessor: Callable,
+        accessor: Callable = DEFAULT_ACCESSOR,
         add_first: bool = True,
         **kwargs,
     ):
@@ -146,4 +137,6 @@ class BaseBackend(AbstractContextManager):
         )
         self._update_metadata(bounds, version)
 
+        if self.path:
+            self.write()
         return

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -1,6 +1,6 @@
 """cogeo-mosaic AWS DynamoDB backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import functools
 import itertools
@@ -15,7 +15,7 @@ import mercantile
 
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import find_quadkeys
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 
 
 class DynamoDBBackend(BaseBackend):
@@ -31,6 +31,7 @@ class DynamoDBBackend(BaseBackend):
         """Initialize DynamoDBBackend."""
         self.client = client or boto3.resource("dynamodb", region_name=region)
         self.table = self.client.Table(table_name)
+        self.path = f"dynamodb://{region}/{table_name}"
 
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
@@ -68,19 +69,6 @@ class DynamoDBBackend(BaseBackend):
         meta = json.loads(json.dumps(self.metadata), parse_float=Decimal)
         meta["quadkey"] = "-1"
         self.table.put_item(Item=meta)
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = True,
-        **kwargs: Any
-    ):
-        """Update the mosaicjson document."""
-        if not overwrite:
-            raise Exception("Overwrite has to be set to True")
-
-        self._update(features, accessor, **kwargs)
 
     def _create_table(self, billing_mode: str = "PAY_PER_REQUEST"):
         # Define schema for primary key

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -1,13 +1,13 @@
 """cogeo-mosaic File backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import json
 import functools
 
 import mercantile
 
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import (
     _compress_gz_json,
@@ -52,18 +52,6 @@ class FileBackend(BaseBackend):
                 f.write(_compress_gz_json(body))
             else:
                 f.write(json.dumps(body).encode("utf-8"))
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any,
-    ):
-        """Update the mosaicjson document."""
-        self._update(features, accessor, **kwargs)
-        if overwrite:
-            self.write()
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/cogeo_mosaic/backends/http.py
+++ b/cogeo_mosaic/backends/http.py
@@ -1,15 +1,14 @@
 """cogeo-mosaic HTTP backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import json
-import warnings
 import functools
 
 import requests
 import mercantile
 
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import _decompress_gz, get_assets_from_json
 
@@ -24,7 +23,7 @@ class HttpBackend(BaseBackend):
         **kwargs: Any
     ):
         """Initialize HttpBackend."""
-        self.url = url
+        self.path = url
 
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
@@ -46,24 +45,16 @@ class HttpBackend(BaseBackend):
         """Write mosaicjson document."""
         raise NotImplementedError
 
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any
-    ):
+    def update(self, *args, **kwargs: Any):
         """Update the mosaicjson document."""
-        self._update(features, accessor, **kwargs)
-        if overwrite:
-            warnings.warn("Overwrite is not possible for http backend")
+        raise NotImplementedError
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:
         """Get mosaicjson document."""
-        body = requests.get(self.url).content
+        body = requests.get(self.path).content
 
-        if gzip or (gzip is None and self.url.endswith(".gz")):
+        if gzip or (gzip is None and self.path.endswith(".gz")):
             body = _decompress_gz(body)
 
         return MosaicJSON(**json.loads(body))

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -1,6 +1,6 @@
 """cogeo-mosaic AWS S3 backend."""
 
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Union
 
 import json
 import functools
@@ -9,7 +9,7 @@ import mercantile
 
 from boto3.session import Session as boto3_session
 
-from cogeo_mosaic.mosaic import MosaicJSON, DEFAULT_ACCESSOR
+from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import (
     _compress_gz_json,
@@ -27,12 +27,13 @@ class S3Backend(BaseBackend):
         key: str,
         mosaic_def: Optional[Union[MosaicJSON, Dict]] = None,
         client: Optional[boto3_session.client] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ):
         """Initialize S3Backend."""
         self.client = client or boto3_session().client("s3")
         self.key = key
         self.bucket = bucket
+        self.path = f"s3://{bucket}/{key}"
 
         if mosaic_def is not None:
             self.mosaic_def = MosaicJSON(**dict(mosaic_def))
@@ -59,18 +60,6 @@ class S3Backend(BaseBackend):
             body = json.dumps(body).encode("utf-8")
 
         _aws_put_data(self.key, self.bucket, body, client=self.client, **kwargs)
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        accessor: Callable = DEFAULT_ACCESSOR,
-        overwrite: bool = False,
-        **kwargs: Any
-    ):
-        """Update the mosaicjson document."""
-        self._update(features, accessor, **kwargs)
-        if overwrite:
-            self.write()
 
     @functools.lru_cache(maxsize=512)
     def _read(self, gzip: bool = None) -> MosaicJSON:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,22 +47,16 @@ def test_update_valid():
         result = runner.invoke(cogeo_cli, ["update", "list.txt", "mosaic.json"])
         assert not result.exception
         assert result.exit_code == 0
-        updated_mosaic = json.loads(result.output)
-        updated_mosaic["version"] == "1.0.1"
-        assert not mosaic_content.tiles == updated_mosaic["tiles"]
+        with open("mosaic.json", "r") as f:
+            updated_mosaic = json.load(f)
+            updated_mosaic["version"] == "1.0.1"
+            assert not mosaic_content.tiles == updated_mosaic["tiles"]
+
+        with open("mosaic.json", "w") as f:
+            f.write(json.dumps(MosaicJSON.from_urls([asset1]).dict(exclude_none=True)))
 
         result = runner.invoke(
             cogeo_cli, ["update", "list.txt", "mosaic.json", "--add-last"]
-        )
-        assert not result.exception
-        assert result.exit_code == 0
-        updated_mosaic = json.loads(result.output)
-        updated_mosaic["version"] == "1.0.1"
-        assert mosaic_content.tiles == updated_mosaic["tiles"]
-
-        result = runner.invoke(
-            cogeo_cli,
-            ["update", "list.txt", "mosaic.json", "--overwrite", "--add-last"],
         )
         assert not result.exception
         assert result.exit_code == 0


### PR DESCRIPTION
This PR force `write` on `update` and thus disable update for HTTP Backends.

Changes:
- add `self.path` in mosaic to store url or path
- removes the unnecessary `_update`

cc @kylebarron @geospatial-jeff 