### PR TITLE
add "quadkeys" properties and fix overviews for dynamoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ Commands:
   create                Create mosaic definition from list of files
   create-from-features  Create mosaic definition from GeoJSON features or features collection
   footprint             Create geojson from list of files
-  overview              [EXPERIMENT] Create COG overviews for a mosaic
-  update                Create mosaic definition from list of files
+  overview              [EXPERIMENTAL] Create a low resolution version of a mosaic
+  update                Update a mosaic definition from list of files
 ```
 
 ### Create Mosaic definition
@@ -130,6 +130,18 @@ curl https://earth-search.aws.element84.com/collections/landsat-8-l1/items | cog
     ...
 }
 ```
+
+### Create Mosaic Overview [experimental]
+
+The CLI provides an `overview` command to create low-resolution version of a mosaic. 
+This is hightly experimental and might incure some cost if you are hosting mosaic on DynamoDB or COG files on S3. To create the overview, the `overview` method will fetch all the asset's overviews (COG internal overview) and construct one or multiple COG .
+
+```
+$ cogeo-mosaic overview s3://bucket/mymosaic.json
+```
+
+![](https://user-images.githubusercontent.com/10407788/80844578-fa7c5000-8bd4-11ea-9eb8-5d1f84461dad.png)
+
 
 # Image Order
 

--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -60,6 +60,11 @@ class BaseBackend(AbstractContextManager):
         """Return Quadkey zoom property."""
         return self.mosaic_def.quadkey_zoom or self.mosaic_def.minzoom
 
+    @property
+    def quadkeys(self) -> List[str]:
+        """Return the list of quadkey tiles."""
+        return [qk for qk, _ in self.mosaic_def.tiles.items()]
+
     @abc.abstractmethod
     def write(self):
         """Upload new MosaicJSON to backend."""

--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -61,9 +61,9 @@ class BaseBackend(AbstractContextManager):
         return self.mosaic_def.quadkey_zoom or self.mosaic_def.minzoom
 
     @property
-    def quadkeys(self) -> List[str]:
-        """Return the list of quadkey tiles."""
-        return [qk for qk, _ in self.mosaic_def.tiles.items()]
+    def _quadkeys(self) -> List[str]:
+        """Return the list of quadkeys"""
+        return list(self.mosaic_def.tiles.keys())
 
     @abc.abstractmethod
     def write(self):

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -48,6 +48,12 @@ class DynamoDBBackend(BaseBackend):
         tile = mercantile.tile(lng, lat, self.quadkey_zoom)
         return self.get_assets(tile.x, tile.y, tile.z)
 
+    @property
+    def quadkeys(self) -> List[str]:
+        """Return the list of quadkey tiles."""
+        resp = self.table.scan(ProjectionExpression="quadkey")
+        return [qk["quadkey"] for qk in resp["Items"] if qk["quadkey"] != "-1"]
+
     def write(self):
         """Write mosaicjson document to AWS DynamoDB."""
         self._create_table()

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -49,9 +49,12 @@ class DynamoDBBackend(BaseBackend):
         return self.get_assets(tile.x, tile.y, tile.z)
 
     @property
-    def quadkeys(self) -> List[str]:
+    def _quadkeys(self) -> List[str]:
         """Return the list of quadkey tiles."""
-        resp = self.table.scan(ProjectionExpression="quadkey")
+        warnings.warn(
+            "Performing full scan operation might be slow and expensive on large database."
+        )
+        resp = self.table.scan(ProjectionExpression="quadkey")  # TODO: Add pagination
         return [qk["quadkey"] for qk in resp["Items"] if qk["quadkey"] != "-1"]
 
     def write(self):

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -11,8 +11,9 @@ from affine import Affine
 from rasterio.io import MemoryFile
 from rasterio.windows import Window
 from rio_cogeo.cogeo import cog_translate
-from rio_cogeo.utils import _meters_per_pixel, has_mask_band
+from rio_cogeo.utils import _meters_per_pixel
 from rio_tiler.io import cogeo
+from rio_tiler.utils import has_mask_band, non_alpha_indexes
 from rio_tiler_mosaic.methods import defaults
 from rio_tiler_mosaic.mosaic import mosaic_tiler
 from supermercado.burntiles import tile_extrema
@@ -26,6 +27,7 @@ def _get_info(asset: str) -> Tuple:
         description = [
             src_dst.descriptions[b - 1] for i, b in enumerate(src_dst.indexes)
         ]
+        indexes = non_alpha_indexes(src_dst)
         mask = has_mask_band(src_dst)
         return (
             src_dst.count,
@@ -34,14 +36,8 @@ def _get_info(asset: str) -> Tuple:
             src_dst.tags(),
             src_dst.nodata,
             mask,
+            indexes,
         )
-
-
-# TODO: Won't work with DynamoDB
-def _get_asset_example(mosaic_def: Dict) -> str:
-    t = list(mosaic_def["tiles"].keys())[0]
-    asset = mosaic_def["tiles"][t][0]
-    return asset
 
 
 def _split_extrema(extrema: Dict, max_ovr: int = 6, tilesize: int = 256):
@@ -96,14 +92,14 @@ def create_low_level_cogs(
         Rasterio Env options.
 
     """
-    # TODO: Won't work for DynamoDB
     with MosaicBackend(mosaic_path) as mosaic:
-        mosaic_def = mosaic.mosaic_def.dict()
+        base_zoom = mosaic.metadata["minzoom"] - 1
+        bounds = mosaic.metadata["bounds"]
+        mosaic_quadkeys = mosaic.quadkeys
 
-        base_zoom = mosaic_def["minzoom"] - 1
-        bounds = mosaic_def["bounds"]
-        asset = _get_asset_example(mosaic_def)
-        info = _get_info(asset)
+        tile = mercantile.quadkey_to_tile(mosaic_quadkeys[0])
+        assets = mosaic.tile(*tile)
+        info = _get_info(assets[0])
 
         extrema = tile_extrema(bounds, base_zoom)
         tilesize = 256
@@ -126,7 +122,7 @@ def create_low_level_cogs(
             params = dict(
                 driver="GTiff",
                 dtype=info[1],
-                count=info[0],
+                count=len(info[6]),
                 width=width,
                 height=height,
                 crs="epsg:3857",
@@ -146,7 +142,13 @@ def create_low_level_cogs(
                             idx, window = wind
                             x = extrema["x"]["min"] + idx[1]
                             y = extrema["y"]["min"] + idx[0]
-                            assets = list(set(mosaic.tile(x, y, base_zoom)))
+
+                            assets = mosaic.tile(x, y, base_zoom)
+                            if not assets:
+                                raise Exception(
+                                    f"No asset for tile {x}-{y}-{base_zoom}"
+                                )
+
                             if assets:
                                 tile, mask = mosaic_tiler(
                                     assets,
@@ -154,11 +156,14 @@ def create_low_level_cogs(
                                     y,
                                     base_zoom,
                                     cogeo.tile,
+                                    indexes=info[6],
                                     tilesize=tilesize,
                                     pixel_selection=defaults.FirstMethod(),
                                 )
                                 if tile is None:
-                                    raise Exception("Empty")
+                                    raise Exception(
+                                        f"ERROR - mosaic-tiler returned empty for tile {x}-{y}-{base_zoom}"
+                                    )
 
                             return window, tile, mask
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 
 from setuptools import find_packages, setup
 
+with open("README.md") as f:
+    readme = f.read()
+
 # Runtime requirements.
 inst_reqs = [
     "mercantile",
@@ -23,9 +26,10 @@ extra_reqs = {
 
 setup(
     name="cogeo-mosaic",
-    version="2.0.1",
-    description=u"Create Cloud Optimized GeoTIFF mosaicsJSON.",
-    long_description=u"Create Cloud Optimized GeoTIFF mosaicsJSON.",
+    version="3.0a1",
+    description=u"Create mosaicJSON.",
+    long_description=readme,
+    long_description_content_type="text/markdown",
     python_requires=">=3",
     classifiers=[
         "Intended Audience :: Information Technology",
@@ -33,8 +37,9 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering :: GIS",
     ],
-    keywords="COG COGEO Mosaic GIS",
+    keywords="COG Mosaic GIS",
     author=u"Vincent Sarago",
     author_email="vincent@developmentseed.org",
     url="https://github.com/developmentseed/cogeo-mosaic",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,3 +129,13 @@ def test_overview_valid():
             assert src_dst.height == 512
             assert src_dst.overviews(1) == [2, 4]
             assert not src_dst.compression
+
+
+def test_overview_DynamoDB():
+    """Should work as expected."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cogeo_cli, ["overview", "dynamodb://afakemosaic"], input="n\n"
+    )
+    assert not result.exception
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds `.quadkeys` property for the backends in order to retrieve the list of quadkeys in the mosaicjson. 

For dynamoDB we are doing a scan operation but returning only the quadkey value (not the full item) so with relatively small mosaic the body should be <1Mb. We could add pagination if needed later

cc @kylebarron 