### PR TITLE
Scaffolding for simple Mkdocs Material website

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+notifications:
+  email: false
+python:
+    - "3.7"
+script:
+  - git config user.name "Kyle Barron";
+  - git config user.email "kylebarron2@gmail.com";
+  - git remote add gh-token "https://developmentseed:${GITHUB_TOKEN}@github.com/developmentseed/cogeo-mosaic.git";
+  - git fetch gh-token && git fetch gh-token gh-pages:gh-pages;
+  - pip install -U mkdocs mkdocs-material pygments;
+  - mkdocs gh-deploy -v --clean --remote-name gh-token -b gh-pages --force;

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project Information
 site_name: 'cogeo-mosaic'
-site_description: 'mosaicJSON tools for Landsat 8 imagery'
+site_description: 'Create and use COG mosaic based on mosaicJSON'
 
 docs_dir: 'docs'
 site_dir: 'build'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,11 +22,8 @@ extra:
 # Layout
 nav:
   - Home: 'index.md'
-  - Install: 'install.md'
-  - Examples:
-    - Global Basemap: 'examples/global.md'
-    - STAC Features: 'examples/stac.md'
-  - CLI: 'cli.md'
+  - V3 Migration: 'v3_migration.md'
+  - Advanced Topics: 'AdvancedTopics.md'
 
 # Theme
 theme:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,78 @@
+# Project Information
+site_name: 'cogeo-mosaic'
+site_description: 'mosaicJSON tools for Landsat 8 imagery'
+
+docs_dir: 'docs'
+site_dir: 'build'
+
+# Repository
+repo_name: 'developmentseed/cogeo-mosaic'
+repo_url: 'https://github.com/developmentseed/cogeo-mosaic'
+edit_uri: 'blob/master/docs/src/'
+site_url: 'https://developmentseed.github.io/cogeo-mosaic/'
+
+# Social links
+extra:
+  social:
+    - icon: 'fontawesome/brands/github'
+      link: 'https://github.com/developmentseed'
+    - icon: 'fontawesome/brands/twitter'
+      link: 'https://twitter.com/developmentseed'
+
+# Layout
+nav:
+  - Home: 'index.md'
+  - Install: 'install.md'
+  - Examples:
+    - Global Basemap: 'examples/global.md'
+    - STAC Features: 'examples/stac.md'
+  - CLI: 'cli.md'
+
+# Theme
+theme:
+  icon:
+    logo: 'material/home'
+    repo: 'fontawesome/brands/github'
+  name: 'material'
+  language: 'en'
+  palette:
+    primary: 'blue'
+    accent:  'light blue'
+  font:
+    text: 'Nunito Sans'
+    code: 'Fira Code'
+
+# Uncomment if I use math in the docs in the future
+# extra_javascript:
+#     - helpers/helpers.js
+#     - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML
+
+# These extensions are chosen to be a superset of Pandoc's Markdown.
+# This way, I can write in Pandoc's Markdown and have it be supported here.
+# https://pandoc.org/MANUAL.html
+markdown_extensions:
+    - admonition
+    - attr_list
+    - codehilite:
+        guess_lang: false
+    - def_list
+    - footnotes
+    - pymdownx.arithmatex
+    - pymdownx.betterem
+    - pymdownx.caret:
+        insert: false
+    - pymdownx.details
+    - pymdownx.emoji
+    - pymdownx.escapeall:
+        hardbreak: true
+        nbsp: true
+    - pymdownx.magiclink:
+        hide_protocol: true
+        repo_url_shortener: true
+    - pymdownx.smartsymbols
+    - pymdownx.superfences
+    - pymdownx.tasklist:
+        custom_checkbox: true
+    - pymdownx.tilde
+    - toc:
+        permalink: true


### PR DESCRIPTION
- Adds `.travis.yml` file to auto-build/deploy website on new commits. You'd have to enable Travis CI for the repository and add a Github token as the `GITHUB_TOKEN` environment variable that allows Travis to push to the `gh-pages` branch. You probably want to also change the git config name/email.
- Adds a symlink for `docs/index.md` to the top-level README. Mkdocs only sees docs in the `docs/` folder.
- Adds a pretty standard `mkdocs.yml` config. You'll probably want to change `site_url` to whatever the public url would be.


![image](https://user-images.githubusercontent.com/15164633/82839137-9a9f5f00-9e8b-11ea-9da6-4c926caa5b24.png)
