### PR TITLE
Default to 1 thread for Mosaic overview creation

### DIFF
--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -268,8 +268,8 @@ def footprint(input_files, output, threads, quiet):
 @click.option(
     "--threads",
     type=int,
-    default=lambda: os.environ.get("MAX_THREADS", multiprocessing.cpu_count() * 5),
-    help="threads",
+    default=1,
+    help="# of Python threads. 1 thread is recommended, as GDAL can have issues when multiple threads read the same file.",
 )
 @click.option(
     "--overview-level",


### PR DESCRIPTION
I finally have the most conclusive evidence yet of GDAL(?) issues with threading.

```bash
export AWS_REQUEST_PAYER="requester"
cogeo-mosaic overview naip_2016_2018_032023.json
mv naip_2016_2018_032023_0.tif naip_2016_2018_032023_0.bak.tif
cogeo-mosaic overview --threads=1 naip_2016_2018_032023.json
```

[naip_2016_2018_032023.json.zip](https://github.com/developmentseed/cogeo-mosaic/files/4906272/naip_2016_2018_032023.json.zip)


Since my computer has 8 physical CPU cores and 16 logical cores, the default setting of `multiprocessing.cpu_count() * 5` uses **_80_** threads.

Default (80) threads: 
![image](https://user-images.githubusercontent.com/15164633/87216221-d9358f80-c2fa-11ea-805d-13f3ef83fd8a.png)

One thread: (note that the remaining black areas are expected; NAIP images aren't taken over water)
![image](https://user-images.githubusercontent.com/15164633/87216220-d33fae80-c2fa-11ea-846d-282c2e45977a.png)


