### PR TITLE
Small overview refactor

### DIFF
--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -45,10 +45,8 @@ def _split_extrema(extrema: Dict, max_ovr: int = 6, tilesize: int = 256):
     """Create multiple extremas."""
     nb_ovrtile = 2 ** max_ovr
     extr = []
-    for _, x in enumerate(range(extrema["x"]["min"], extrema["x"]["max"], nb_ovrtile)):
-        for _, y in enumerate(
-            range(extrema["y"]["min"], extrema["y"]["max"], nb_ovrtile)
-        ):
+    for x in range(extrema["x"]["min"], extrema["x"]["max"], nb_ovrtile):
+        for y in range(extrema["y"]["min"], extrema["y"]["max"], nb_ovrtile):
             maxx = (
                 x + nb_ovrtile
                 if x + nb_ovrtile < extrema["x"]["max"]
@@ -65,8 +63,8 @@ def _split_extrema(extrema: Dict, max_ovr: int = 6, tilesize: int = 256):
 
 def _get_blocks(extrema):
     for j in range(extrema["y"]["max"] - extrema["y"]["min"]):
-        row = j * 256
         for i in range(extrema["x"]["max"] - extrema["x"]["min"]):
+            row = j * 256
             col = i * 256
             yield (j, i), Window(col_off=col, row_off=row, width=256, height=256)
 

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -171,7 +171,7 @@ def create_low_level_cogs(
                                 length=len(future_work),
                                 show_percent=True,
                             ) as future:
-                                for res in future:
+                                for result in future:
                                     pass
 
                         for f in _filter_futures(future_work):

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -47,16 +47,8 @@ def _split_extrema(extrema: Dict, max_ovr: int = 6, tilesize: int = 256):
     extr = []
     for x in range(extrema["x"]["min"], extrema["x"]["max"], nb_ovrtile):
         for y in range(extrema["y"]["min"], extrema["y"]["max"], nb_ovrtile):
-            maxx = (
-                x + nb_ovrtile
-                if x + nb_ovrtile < extrema["x"]["max"]
-                else extrema["x"]["max"]
-            )
-            maxy = (
-                y + nb_ovrtile
-                if y + nb_ovrtile < extrema["y"]["max"]
-                else extrema["y"]["max"]
-            )
+            maxx = min(x + nb_ovrtile, extrema["x"]["max"])
+            maxy = min(y + nb_ovrtile, extrema["y"]["max"])
             extr.append({"x": {"min": x, "max": maxx}, "y": {"min": y, "max": maxy}})
     return extr
 

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -31,13 +31,13 @@ def _get_info(asset: str) -> Tuple:
         indexes = non_alpha_indexes(src_dst)
         mask = has_mask_band(src_dst)
         return {
-            'n_bands': src_dst.count,
-            'dtype': src_dst.dtypes[0],
-            'band_desc': description,
-            'tags': src_dst.tags(),
-            'nodata': src_dst.nodata,
-            'mask': mask,
-            'indexes': indexes,
+            "n_bands": src_dst.count,
+            "dtype": src_dst.dtypes[0],
+            "band_desc": description,
+            "tags": src_dst.tags(),
+            "nodata": src_dst.nodata,
+            "mask": mask,
+            "indexes": indexes,
         }
 
 
@@ -124,13 +124,13 @@ def create_low_level_cogs(
 
             params = dict(
                 driver="GTiff",
-                dtype=info['dtype'],
-                count=len(info['indexes']),
+                dtype=info["dtype"],
+                count=len(info["indexes"]),
                 width=width,
                 height=height,
                 crs="epsg:3857",
                 transform=Affine(res, 0, w, 0, -res, n),
-                nodata=info['nodata'],
+                nodata=info["nodata"],
                 tiled=True,
                 blockxsize=256,
                 blockysize=256,
@@ -164,7 +164,7 @@ def create_low_level_cogs(
                                     y,
                                     base_zoom,
                                     cogeo.tile,
-                                    indexes=info['indexes'],
+                                    indexes=info["indexes"],
                                     tilesize=tilesize,
                                     pixel_selection=defaults.FirstMethod(),
                                 )
@@ -191,7 +191,7 @@ def create_low_level_cogs(
                                 continue
 
                             mem.write(tile, window=window)
-                            if info['mask']:
+                            if info["mask"]:
                                 mem.write_mask(mask.astype("uint8"), window=window)
 
                         cog_translate(

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -68,6 +68,7 @@ def create_low_level_cogs(
     max_overview_level: int = 6,
     config: Dict = None,
     threads=1,
+    tilesize=256,
 ) -> None:
     """
     Create WebOptimized Overview COG from a mosaic definition file.
@@ -85,7 +86,6 @@ def create_low_level_cogs(
     """
     with MosaicBackend(mosaic_path) as mosaic:
         base_zoom = mosaic.metadata["minzoom"] - 1
-        mosaic_quadkey_zoom = mosaic.quadkey_zoom
         bounds = mosaic.metadata["bounds"]
         mosaic_quadkeys = set(mosaic._quadkeys)
 
@@ -95,7 +95,6 @@ def create_low_level_cogs(
         info = _get_info(assets[0])
 
         extrema = tile_extrema(bounds, base_zoom)
-        tilesize = 256
         res = _meters_per_pixel(base_zoom, 0, tilesize=tilesize)
 
         # Create multiples files if coverage is too big
@@ -137,7 +136,7 @@ def create_low_level_cogs(
                             y = extrema["y"]["min"] + idx[0]
                             t = mercantile.Tile(x, y, base_zoom)
 
-                            kds = set(find_quadkeys(t, mosaic_quadkey_zoom))
+                            kds = set(find_quadkeys(t, mosaic.quadkey_zoom))
                             if not mosaic_quadkeys.intersection(kds):
                                 return window, None, None
 

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -30,15 +30,15 @@ def _get_info(asset: str) -> Tuple:
         ]
         indexes = non_alpha_indexes(src_dst)
         mask = has_mask_band(src_dst)
-        return (
-            src_dst.count,
-            src_dst.dtypes[0],
-            description,
-            src_dst.tags(),
-            src_dst.nodata,
-            mask,
-            indexes,
-        )
+        return {
+            'n_bands': src_dst.count,
+            'dtype': src_dst.dtypes[0],
+            'band_desc': description,
+            'tags': src_dst.tags(),
+            'nodata': src_dst.nodata,
+            'mask': mask,
+            'indexes': indexes,
+        }
 
 
 def _split_extrema(extrema: Dict, max_ovr: int = 6, tilesize: int = 256):
@@ -124,13 +124,13 @@ def create_low_level_cogs(
 
             params = dict(
                 driver="GTiff",
-                dtype=info[1],
-                count=len(info[6]),
+                dtype=info['dtype'],
+                count=len(info['indexes']),
                 width=width,
                 height=height,
                 crs="epsg:3857",
                 transform=Affine(res, 0, w, 0, -res, n),
-                nodata=info[4],
+                nodata=info['nodata'],
                 tiled=True,
                 blockxsize=256,
                 blockysize=256,
@@ -164,7 +164,7 @@ def create_low_level_cogs(
                                     y,
                                     base_zoom,
                                     cogeo.tile,
-                                    indexes=info[6],
+                                    indexes=info['indexes'],
                                     tilesize=tilesize,
                                     pixel_selection=defaults.FirstMethod(),
                                 )
@@ -191,7 +191,7 @@ def create_low_level_cogs(
                                 continue
 
                             mem.write(tile, window=window)
-                            if info[5]:
+                            if info['mask']:
                                 mem.write_mask(mask.astype("uint8"), window=window)
 
                         cog_translate(


### PR DESCRIPTION
These changes are for discussion. I'm using this code right now to create NAIP overviews

- Adds low-memory mode, where fetched images are written directly to a GeoTIFF on disk.
- Uses `dict` instead of `tuple` for `info` internally, for clearer code