### PR TITLE
allow pixel_selection and --not-in-memory option for overview cli

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,10 @@
+3.0a6 (TBD)
+------------------
+- Use environement variable to set/disable cache (#93, autho @geospatial-jeff)
+- Allow Threads configuration for overview command (author @kylebarron)
+- add --in-memory/--no-in-memory to control temporary files creation for `overview` function. 
+- allow pixel_selection method options for `overview` function. 
+
 3.0a5 (2020-06-29)
 ------------------
 - remove FTP from supported backend (#87, author @geospatial-jeff)

--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Commands:
   create                Create mosaic definition from list of files
   create-from-features  Create mosaic definition from GeoJSON features or features collection
   footprint             Create geojson from list of files
-  overview              [EXPERIMENTAL] Create a low resolution version of a mosaic
+  info                  Return info about the mosaic
+  overview              [EXPERIMENTAL] Create a low resolution mosaic image from a MosaicJSON.
   update                Update a mosaic definition from list of files
+  upload                Upload mosaic definition to backend
 ```
 
 ### Create Mosaic definition
@@ -142,7 +144,6 @@ $ cogeo-mosaic overview s3://bucket/mymosaic.json
 ```
 
 ![](https://user-images.githubusercontent.com/10407788/80844578-fa7c5000-8bd4-11ea-9eb8-5d1f84461dad.png)
-
 
 # Image Order
 

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -2,18 +2,21 @@
 
 import random
 from concurrent import futures
-from typing import Dict, Tuple
+from contextlib import ExitStack
+from typing import Any, Dict, List, Tuple
 
 import click
 import mercantile
+import numpy
 import rasterio
 from affine import Affine
 from rasterio.io import MemoryFile
+from rasterio.rio.overview import get_maximum_overview_level
+from rasterio.shutil import copy
 from rasterio.windows import Window
-from rio_cogeo.cogeo import cog_translate
+from rio_cogeo.cogeo import TemporaryRasterFile
 from rio_cogeo.utils import _meters_per_pixel
-from rio_tiler.io import cogeo
-from rio_tiler.utils import has_mask_band, non_alpha_indexes
+from rio_tiler.io import COGReader
 from rio_tiler_mosaic.methods import defaults
 from rio_tiler_mosaic.mosaic import mosaic_tiler
 from supermercado.burntiles import tile_extrema
@@ -22,65 +25,71 @@ from cogeo_mosaic.backends import MosaicBackend
 from cogeo_mosaic.backends.utils import find_quadkeys
 from cogeo_mosaic.utils import _filter_futures
 
-
-def _get_info(asset: str) -> Tuple:
-    with rasterio.open(asset) as src_dst:
-        description = [
-            src_dst.descriptions[b - 1] for i, b in enumerate(src_dst.indexes)
-        ]
-        indexes = non_alpha_indexes(src_dst)
-        mask = has_mask_band(src_dst)
-        return (
-            src_dst.count,
-            src_dst.dtypes[0],
-            description,
-            src_dst.tags(),
-            src_dst.nodata,
-            mask,
-            indexes,
-        )
+PIXSEL_METHODS = {
+    "first": defaults.FirstMethod,
+    "highest": defaults.HighestMethod,
+    "lowest": defaults.LowestMethod,
+    "mean": defaults.MeanMethod,
+    "median": defaults.MedianMethod,
+    "stdev": defaults.StdevMethod,
+}
 
 
-def _split_extrema(extrema: Dict, max_ovr: int = 6, tilesize: int = 256):
+def _tile(
+    src_path: str, *args: Any, **kwargs: Any
+) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    with COGReader(src_path) as cog:
+        return cog.tile(*args, **kwargs)
+
+
+def _get_info(src_path: str) -> Dict:
+    with COGReader(src_path) as cog:
+        info = cog.info.copy()
+        info["nodata_value"] = cog.dataset.nodata
+
+    return info
+
+
+def _split_extrema(extrema: Dict, max_ovr: int = 6) -> List[Dict]:
     """Create multiple extremas."""
     nb_ovrtile = 2 ** max_ovr
     extr = []
-    for _, x in enumerate(range(extrema["x"]["min"], extrema["x"]["max"], nb_ovrtile)):
-        for _, y in enumerate(
-            range(extrema["y"]["min"], extrema["y"]["max"], nb_ovrtile)
-        ):
-            maxx = (
-                x + nb_ovrtile
-                if x + nb_ovrtile < extrema["x"]["max"]
-                else extrema["x"]["max"]
-            )
-            maxy = (
-                y + nb_ovrtile
-                if y + nb_ovrtile < extrema["y"]["max"]
-                else extrema["y"]["max"]
-            )
+    for x in range(extrema["x"]["min"], extrema["x"]["max"], nb_ovrtile):
+        maxx = min(x + nb_ovrtile, extrema["x"]["max"])
+        for y in range(extrema["y"]["min"], extrema["y"]["max"], nb_ovrtile):
+            maxy = min(y + nb_ovrtile, extrema["y"]["max"])
+
             extr.append({"x": {"min": x, "max": maxx}, "y": {"min": y, "max": maxy}})
+
     return extr
 
 
-def _get_blocks(extrema):
+def _get_blocks(extrema: Dict, tilesize: int = 256):
     for j in range(extrema["y"]["max"] - extrema["y"]["min"]):
-        row = j * 256
+        row = j * tilesize
         for i in range(extrema["x"]["max"] - extrema["x"]["min"]):
-            col = i * 256
-            yield (j, i), Window(col_off=col, row_off=row, width=256, height=256)
+            col = i * tilesize
+
+            yield (j, i), Window(
+                col_off=col, row_off=row, width=tilesize, height=tilesize
+            )
 
 
-def create_low_level_cogs(
+def create_overview_cogs(
     mosaic_path: str,
     output_profile: Dict,
     prefix: str = "mosaic_ovr",
     max_overview_level: int = 6,
+    method: str = "first",
     config: Dict = None,
     threads=1,
+    in_memory: bool = True,
 ) -> None:
     """
-    Create WebOptimized Overview COG from a mosaic definition file.
+    Create Low resolution mosaic image from a mosaicJSON.
+
+    The output will be a web optimized COG with bounds matching the mosaicJSON bounds and
+    with its resolution matching the mosaic MinZoom - 1.
 
     Attributes
     ----------
@@ -89,10 +98,18 @@ def create_low_level_cogs(
     output_profile : dict, required
     prefix : str
     max_overview_level : int
+    method: str, optional
+        pixel_selection method name (default is 'first').
     config : dict
         Rasterio Env options.
+    threads: int, optional
+        maximum number of threads to use (default is 1).
+    in_memory: bool, optional
+        Force COG creation in memory (default is True).
 
     """
+    pixel_method = PIXSEL_METHODS[method]
+
     with MosaicBackend(mosaic_path) as mosaic:
         base_zoom = mosaic.metadata["minzoom"] - 1
         mosaic_quadkey_zoom = mosaic.quadkey_zoom
@@ -106,14 +123,15 @@ def create_low_level_cogs(
 
         extrema = tile_extrema(bounds, base_zoom)
         tilesize = 256
-        res = _meters_per_pixel(base_zoom, 0, tilesize=tilesize)
+        resolution = _meters_per_pixel(base_zoom, 0, tilesize=tilesize)
 
         # Create multiples files if coverage is too big
-        extremas = _split_extrema(
-            extrema, max_ovr=max_overview_level, tilesize=tilesize
-        )
+        extremas = _split_extrema(extrema, max_ovr=max_overview_level)
         for ix, extrema in enumerate(extremas):
-            blocks = list(_get_blocks(extrema))
+            click.echo(f"Part {1 + ix}/{len(extremas)}", err=True)
+            output_path = f"{prefix}_{ix}.tif"
+
+            blocks = list(_get_blocks(extrema, tilesize))
             random.shuffle(blocks)
 
             width = (extrema["x"]["max"] - extrema["x"]["min"]) * tilesize
@@ -124,80 +142,82 @@ def create_low_level_cogs(
 
             params = dict(
                 driver="GTiff",
-                dtype=info[1],
-                count=len(info[6]),
+                dtype=info["dtype"],
+                count=len(info["band_descriptions"]),
                 width=width,
                 height=height,
                 crs="epsg:3857",
-                transform=Affine(res, 0, w, 0, -res, n),
-                nodata=info[4],
-                tiled=True,
-                blockxsize=256,
-                blockysize=256,
+                transform=Affine(resolution, 0, w, 0, -resolution, n),
+                nodata=info["nodata_value"],
             )
+            params.update(**output_profile)
 
             config = config or {}
             with rasterio.Env(**config):
-                with MemoryFile() as memfile:
-                    with memfile.open(**params) as mem:
-
-                        def _get_tile(wind):
-                            idx, window = wind
-                            x = extrema["x"]["min"] + idx[1]
-                            y = extrema["y"]["min"] + idx[0]
-                            t = mercantile.Tile(x, y, base_zoom)
-
-                            kds = set(find_quadkeys(t, mosaic_quadkey_zoom))
-                            if not mosaic_quadkeys.intersection(kds):
-                                return window, None, None
-
-                            assets = mosaic.tile(*t)
-                            if not assets:
-                                raise Exception(
-                                    f"No asset for tile {x}-{y}-{base_zoom}"
-                                )
-
-                            if assets:
-                                tile, mask = mosaic_tiler(
-                                    assets,
-                                    x,
-                                    y,
-                                    base_zoom,
-                                    cogeo.tile,
-                                    indexes=info[6],
-                                    tilesize=tilesize,
-                                    pixel_selection=defaults.FirstMethod(),
-                                )
-
-                            return window, tile, mask
-
-                        with futures.ThreadPoolExecutor(
-                            max_workers=threads
-                        ) as executor:
-                            future_work = [
-                                executor.submit(_get_tile, item) for item in blocks
-                            ]
-                            with click.progressbar(
-                                futures.as_completed(future_work),
-                                length=len(future_work),
-                                show_percent=True,
-                            ) as future:
-                                for res in future:
-                                    pass
-
-                        for f in _filter_futures(future_work):
-                            window, tile, mask = f
-                            if tile is None:
-                                continue
-
-                            mem.write(tile, window=window)
-                            if info[5]:
-                                mem.write_mask(mask.astype("uint8"), window=window)
-
-                        cog_translate(
-                            mem,
-                            f"{prefix}_{ix}.tif",
-                            output_profile,
-                            config=config,
-                            in_memory=True,
+                with ExitStack() as ctx:
+                    if in_memory:
+                        tmpfile = ctx.enter_context(MemoryFile())
+                        tmp_dst = ctx.enter_context(tmpfile.open(**params))
+                    else:
+                        tmpfile = ctx.enter_context(TemporaryRasterFile(output_path))
+                        tmp_dst = ctx.enter_context(
+                            rasterio.open(tmpfile.name, "w", **params)
                         )
+
+                    def _get_tile(wind):
+                        idx, window = wind
+                        x = extrema["x"]["min"] + idx[1]
+                        y = extrema["y"]["min"] + idx[0]
+                        t = mercantile.Tile(x, y, base_zoom)
+
+                        kds = set(find_quadkeys(t, mosaic_quadkey_zoom))
+                        if not mosaic_quadkeys.intersection(kds):
+                            return window, None, None
+
+                        assets = mosaic.tile(*t)
+                        if not assets:
+                            return window, None, None
+
+                        tile, mask = mosaic_tiler(
+                            assets,
+                            x,
+                            y,
+                            base_zoom,
+                            _tile,
+                            tilesize=tilesize,
+                            pixel_selection=pixel_method(),
+                        )
+
+                        return window, tile, mask
+
+                    with futures.ThreadPoolExecutor(max_workers=threads) as executor:
+                        future_work = [
+                            executor.submit(_get_tile, item) for item in blocks
+                        ]
+                        with click.progressbar(
+                            futures.as_completed(future_work),
+                            length=len(future_work),
+                            show_percent=True,
+                        ) as future:
+                            for res in future:
+                                pass
+
+                    for f in _filter_futures(future_work):
+                        window, tile, mask = f
+                        if tile is None:
+                            continue
+
+                        tmp_dst.write(tile, window=window)
+                        if info["nodata_type"] == "Mask":
+                            tmp_dst.write_mask(mask.astype("uint8"), window=window)
+
+                    min_tile_size = tilesize = min(
+                        int(output_profile["blockxsize"]),
+                        int(output_profile["blockysize"]),
+                    )
+                    overview_level = get_maximum_overview_level(
+                        tmp_dst.width, tmp_dst.height, minsize=min_tile_size
+                    )
+                    overviews = [2 ** j for j in range(1, overview_level + 1)]
+                    tmp_dst.build_overviews(overviews)
+                    copy(tmp_dst, output_path, copy_src_overviews=True, **params)

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,20 @@ inst_reqs = [
     "rasterio[s3]",
     "requests",
     "rio-cogeo>=1.1.0",
-    "rio-tiler>=2.0a4",
+    "rio-tiler~=2.0b2",
     "rio-tiler-mosaic>=0.0.1dev4",
     "cachetools",
     "supermercado",
 ]
 
 extra_reqs = {
-    "test": ["pytest", "pytest-cov", "mock"],
-    "dev": ["pytest", "pytest-cov", "pre-commit", "mock"],
+    "test": ["pytest", "pytest-cov"],
+    "dev": ["pytest", "pytest-cov", "pre-commit"],
 }
 
 setup(
     name="cogeo-mosaic",
-    version="3.0a5",
+    version="3.0a6",
     description=u"Create mosaicJSON.",
     long_description=readme,
     long_description_content_type="text/markdown",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,6 +227,8 @@ def test_overview_valid():
         with rasterio.open("ovr_0.tif") as src_dst:
             assert src_dst.width == 512
             assert src_dst.height == 512
+            assert src_dst.profile["blockxsize"] == 128
+            assert src_dst.profile["blockysize"] == 128
             assert src_dst.overviews(1) == [2, 4]
             assert not src_dst.compression
 


### PR DESCRIPTION
closes #89 

also do:
- update for latest rio-tiler
- add `--in-memory/--no-in-memory` and `--method` to the overview command