### PR TITLE
refactor get_assets and cache config.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,7 +20,8 @@ with MosaicBackend(
 ```
 
 * add `to-geojson` CLI to create a GeoJSON from a mosaicJSON document (#128)
-* refactor internal cache
+* refactor internal cache (https://github.com/developmentseed/cogeo-mosaic/pull/131)
+* add progressbar for iterating over quadkeys when creating a mosaic (author @kylebarron, https://github.com/developmentseed/cogeo-mosaic/pull/130)
 
 ### Breaking changes
 
@@ -30,6 +31,8 @@ with MosaicBackend(
 * renamed exception `MosaicExists` to `MosaicExistsError`
 * renamed option `fetch_quadkeys` to `quadkeys` in DynamoDBBackend.info() method
 * add `quadkeys` option in `Backends.info()` to return (or not) the list of quadkeys (https://github.com/developmentseed/cogeo-mosaic/pull/129)
+* moves `get_assets` to the base Backend (https://github.com/developmentseed/cogeo-mosaic/pull/131)
+* remove multi_level mosaic support (https://github.com/developmentseed/cogeo-mosaic/issues/122)
 
 ## 3.0.0a13 (2020-10-13)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,7 @@ with MosaicBackend(
 ```
 
 * add `to-geojson` CLI to create a GeoJSON from a mosaicJSON document (#128)
+* refactor internal cache
 
 ### Breaking changes
 

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -2,19 +2,14 @@
 
 import json
 import os
-from typing import List
 
 import attr
-import mercantile
+from cachetools import TTLCache, cached
 from cachetools.keys import hashkey
 
 from cogeo_mosaic.backends.base import BaseBackend
-from cogeo_mosaic.backends.utils import (
-    _compress_gz_json,
-    _decompress_gz,
-    get_assets_from_json,
-)
-from cogeo_mosaic.cache import lru_cache
+from cogeo_mosaic.backends.utils import _compress_gz_json, _decompress_gz
+from cogeo_mosaic.cache import cache_config
 from cogeo_mosaic.errors import _FILE_EXCEPTIONS, MosaicError, MosaicExistsError
 from cogeo_mosaic.mosaic import MosaicJSON
 
@@ -24,17 +19,6 @@ class FileBackend(BaseBackend):
     """Local File Backend Adapter"""
 
     _backend_name = "File"
-
-    def assets_for_tile(self, x: int, y: int, z: int) -> List[str]:
-        """Retrieve assets for tile."""
-        return get_assets_from_json(self.mosaic_def.tiles, self.quadkey_zoom, x, y, z)
-
-    def assets_for_point(self, lng: float, lat: float) -> List[str]:
-        """Retrieve assets for point."""
-        tile = mercantile.tile(lng, lat, self.quadkey_zoom)
-        return get_assets_from_json(
-            self.mosaic_def.tiles, self.quadkey_zoom, tile.x, tile.y, tile.z
-        )
 
     def write(self, overwrite: bool = False, gzip: bool = None):
         """Write mosaicjson document to a file."""
@@ -52,7 +36,10 @@ class FileBackend(BaseBackend):
                 exc = _FILE_EXCEPTIONS.get(e, MosaicError)  # type: ignore
                 raise exc(str(e)) from e
 
-    @lru_cache(key=lambda self, gzip=None: hashkey(self.path, gzip),)
+    @cached(
+        TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),
+        key=lambda self, gzip=None: hashkey(self.path, gzip),
+    )
     def _read(self, gzip: bool = None) -> MosaicJSON:  # type: ignore
         """Get mosaicjson document."""
         try:

--- a/cogeo_mosaic/backends/utils.py
+++ b/cogeo_mosaic/backends/utils.py
@@ -3,7 +3,7 @@
 import hashlib
 import itertools
 import json
-import os
+import warnings
 import zlib
 from typing import Any, Dict, List
 
@@ -30,7 +30,7 @@ def find_quadkeys(mercator_tile: mercantile.Tile, quadkey_zoom: int) -> List[str
     # get parent
     if mercator_tile.z > quadkey_zoom:
         depth = mercator_tile.z - quadkey_zoom
-        for i in range(depth):
+        for _ in range(depth):
             mercator_tile = mercantile.parent(mercator_tile)
         return [mercantile.quadkey(*mercator_tile)]
 
@@ -51,22 +51,14 @@ def get_assets_from_json(
     tiles: Dict, quadkey_zoom: int, x: int, y: int, z: int
 ) -> List[str]:
     """Find assets."""
+    warnings.warn(
+        "get_assets_from_json will be deprecated in 3.0.0, and is now part of the backends.",
+        DeprecationWarning,
+    )
+
     mercator_tile = mercantile.Tile(x=x, y=y, z=z)
     quadkeys = find_quadkeys(mercator_tile, quadkey_zoom)
-
-    assets = list(itertools.chain.from_iterable([tiles.get(qk, []) for qk in quadkeys]))
-
-    # check if we have a mosaic in the url (.json/.gz)
-    return list(
-        itertools.chain.from_iterable(
-            [
-                get_assets_from_json(tiles, quadkey_zoom, x, y, z)
-                if os.path.splitext(asset)[1] in [".json", ".gz"]
-                else [asset]
-                for asset in assets
-            ]
-        )
-    )
+    return list(itertools.chain.from_iterable([tiles.get(qk, []) for qk in quadkeys]))
 
 
 def _compress_gz_json(data: Dict) -> bytes:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -77,6 +77,10 @@ def test_file_backend():
         assert mosaic.assets_for_tile(150, 182, 9) == ["cog1.tif", "cog2.tif"]
         assert mosaic.assets_for_point(-73, 45) == ["cog1.tif", "cog2.tif"]
 
+        assert len(mosaic.get_assets(150, 182, 9)) == 2
+        assert len(mosaic.get_assets(147, 182, 9)) == 1
+        assert len(mosaic.get_assets(147, 182, 12)) == 0
+
     with MosaicBackend(mosaic_bin, backend_options={"gzip": True}) as mosaic:
         assert isinstance(mosaic, FileBackend)
         assert (

--- a/tests/test_backends_utils.py
+++ b/tests/test_backends_utils.py
@@ -5,6 +5,7 @@ import os
 import re
 
 import mercantile
+import pytest
 
 from cogeo_mosaic.backends import utils
 
@@ -64,12 +65,16 @@ def test_find_quadkeys():
 def test_get_assets_from_json():
     """Get assets list."""
     qkz = mosaic_content.get("quadkey_zoom") or mosaic_content.get("minzoom")
-    assert (
-        len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 150, 182, 9)) == 2
-    )
-    assert (
-        len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 147, 182, 9)) == 1
-    )
-    assert (
-        len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 147, 182, 12)) == 0
-    )
+    with pytest.warns(DeprecationWarning):
+        assert (
+            len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 150, 182, 9))
+            == 2
+        )
+        assert (
+            len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 147, 182, 9))
+            == 1
+        )
+        assert (
+            len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 147, 182, 12))
+            == 0
+        )


### PR DESCRIPTION
While working in refactoring the `get_assets` method I found out that caching implemented in #94 wasn't working 🙈 

This PR does:
- closes #122
- move `get_assets_from_json` to the base class as `get_assets`. Then the `get_assets` method is used by the base methods `assets_for_tile` and `assets_for_point` (reduce code duplication) 

- refactor `cache` to use `settings` (note when TTL and/or MAXSIZE is set to 0, no cache will take place)

cc @geospatial-jeff @kylebarron 