### PR TITLE
Rename http.py -> web.py

### DIFF
--- a/cogeo_mosaic/backends/__init__.py
+++ b/cogeo_mosaic/backends/__init__.py
@@ -6,9 +6,9 @@ from urllib.parse import urlparse
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.dynamodb import DynamoDBBackend
 from cogeo_mosaic.backends.file import FileBackend
-from cogeo_mosaic.backends.http import HttpBackend
 from cogeo_mosaic.backends.s3 import S3Backend
 from cogeo_mosaic.backends.stac import STACBackend
+from cogeo_mosaic.backends.web import HttpBackend
 
 
 def MosaicBackend(url: str, *args: Any, **kwargs: Any) -> BaseBackend:

--- a/cogeo_mosaic/backends/web.py
+++ b/cogeo_mosaic/backends/web.py
@@ -1,4 +1,8 @@
-"""cogeo-mosaic HTTP backend."""
+"""cogeo-mosaic HTTP backend.
+
+This file is named web.py instead of http.py because http is a Python standard
+lib module
+"""
 
 import json
 from typing import Any

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,12 +18,12 @@ from requests.exceptions import HTTPError, RequestException
 from cogeo_mosaic.backends import MosaicBackend
 from cogeo_mosaic.backends.dynamodb import DynamoDBBackend
 from cogeo_mosaic.backends.file import FileBackend
-from cogeo_mosaic.backends.http import HttpBackend
 from cogeo_mosaic.backends.s3 import S3Backend
 from cogeo_mosaic.backends.stac import STACBackend
 from cogeo_mosaic.backends.stac import _fetch as stac_search
 from cogeo_mosaic.backends.stac import default_stac_accessor as stac_accessor
 from cogeo_mosaic.backends.utils import _decompress_gz
+from cogeo_mosaic.backends.web import HttpBackend
 from cogeo_mosaic.errors import MosaicError, MosaicExistsError, NoAssetFoundError
 from cogeo_mosaic.mosaic import MosaicJSON
 
@@ -145,7 +145,7 @@ class MockResponse:
         return self.data
 
 
-@patch("cogeo_mosaic.backends.http.requests")
+@patch("cogeo_mosaic.backends.web.requests")
 def test_http_backend(requests):
     """Test HTTP backend."""
     with open(mosaic_json, "r") as f:


### PR DESCRIPTION
It's probably good to rename `http.py` to another file name because a Python stdlib module is named `http`. So for example I can't even start a Jupyter kernel/session in that directory, because the local `http.py` hides the stdlib import.

Completely open to suggestions of how to rename `http.py` 🤷‍♂️ 