### PR TITLE
[wip] update for rio-tiler 2.0rc and add backend output models.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 3.0.0a17 (TBD)
+
+* update for rio-tiler 2.0rc and add backend output models
+
+
 ## 3.0.0a16 (2020-10-26)
 
 * raise `MosaicNotFoundError` when mosaic doesn't exists in the DynamoDB table.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## 3.0.0a17 (TBD)
+## 3.0.0a17 (2020-11-09)
 
 * update for rio-tiler 2.0rc and add backend output models
 

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -77,17 +77,6 @@ class DynamoDBBackend(BaseBackend):
         self.table = self.client.Table(self.table_name)
         super().__attrs_post_init__()
 
-    def info(self, quadkeys: bool = False):
-        """Mosaic info."""
-        return {
-            "bounds": self.mosaic_def.bounds,
-            "center": self.mosaic_def.center,
-            "maxzoom": self.mosaic_def.maxzoom,
-            "minzoom": self.mosaic_def.minzoom,
-            "name": self.mosaic_def.name if self.mosaic_def.name else self.mosaic_name,
-            "quadkeys": [] if not quadkeys else self._quadkeys,
-        }
-
     @property
     def _quadkeys(self) -> List[str]:
         """Return the list of quadkey tiles."""
@@ -140,7 +129,7 @@ class DynamoDBBackend(BaseBackend):
         Note: `parse_float=Decimal` is required because DynamoDB requires all numbers to be in Decimal type
 
         """
-        meta = json.loads(json.dumps(self.metadata), parse_float=Decimal)
+        meta = json.loads(self.metadata.json(), parse_float=Decimal)
         meta["quadkey"] = self._metadata_quadkey
         meta["mosaicId"] = self.mosaic_name
         self.table.put_item(Item=meta)
@@ -234,7 +223,7 @@ class DynamoDBBackend(BaseBackend):
 
         """
         items = []
-        meta = json.loads(json.dumps(self.metadata), parse_float=Decimal)
+        meta = json.loads(self.metadata.json(), parse_float=Decimal)
         meta = {"quadkey": self._metadata_quadkey, "mosaicId": self.mosaic_name, **meta}
         items.append(meta)
 

--- a/cogeo_mosaic/backends/stac.py
+++ b/cogeo_mosaic/backends/stac.py
@@ -2,13 +2,13 @@
 
 import json
 import os
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Type
 
 import attr
 import requests
 from cachetools import TTLCache, cached
 from cachetools.keys import hashkey
-from rio_tiler.io import BaseReader, STACReader
+from rio_tiler.io import STACReader
 
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.cache import cache_config
@@ -57,7 +57,7 @@ class STACBackend(BaseBackend):
     minzoom: int = attr.ib()
     maxzoom: int = attr.ib()
     mosaic_def: MosaicJSON = attr.ib(default=None)
-    reader: BaseReader = attr.ib(default=STACReader)
+    reader: Type[STACReader] = attr.ib(default=STACReader)
     reader_options: Dict = attr.ib(factory=dict)
     backend_options: Dict = attr.ib(factory=dict)
 
@@ -68,6 +68,7 @@ class STACBackend(BaseBackend):
         self.mosaic_def = self.mosaic_def or self._read(
             self.query, self.minzoom, self.maxzoom, **self.backend_options
         )
+        self.bounds = self.mosaic_def.bounds
 
     def write(self):
         """Write mosaicjson document."""

--- a/cogeo_mosaic/backends/utils.py
+++ b/cogeo_mosaic/backends/utils.py
@@ -38,7 +38,7 @@ def find_quadkeys(mercator_tile: mercantile.Tile, quadkey_zoom: int) -> List[str
     elif mercator_tile.z < quadkey_zoom:
         depth = quadkey_zoom - mercator_tile.z
         mercator_tiles = [mercator_tile]
-        for i in range(depth):
+        for _ in range(depth):
             mercator_tiles = sum([mercantile.children(t) for t in mercator_tiles], [])
 
         mercator_tiles = list(filter(lambda t: t.z == quadkey_zoom, mercator_tiles))

--- a/cogeo_mosaic/models.py
+++ b/cogeo_mosaic/models.py
@@ -1,0 +1,41 @@
+"""cogeo-mosaic models."""
+
+from typing import List, Optional, Tuple
+
+from pydantic import Field
+from rio_tiler.models import RioTilerBaseModel
+
+
+class Info(RioTilerBaseModel):
+    """Mosaic info responses."""
+
+    bounds: List[float] = Field([-180, -90, 180, 90])
+    center: Optional[Tuple[float, float, int]]
+    minzoom: int = Field(0, ge=0, le=30)
+    maxzoom: int = Field(30, ge=0, le=30)
+    name: Optional[str]
+    quadkeys: List[str] = []
+
+
+class Metadata(RioTilerBaseModel):
+    """MosaicJSON model.
+
+    Based on https://github.com/developmentseed/mosaicjson-spec
+
+    """
+
+    mosaicjson: str
+    name: Optional[str]
+    description: Optional[str]
+    version: str = "1.0.0"
+    attribution: Optional[str]
+    minzoom: int = Field(0, ge=0, le=30)
+    maxzoom: int = Field(30, ge=0, le=30)
+    quadkey_zoom: Optional[int]
+    bounds: List[float] = Field([-180, -90, 180, 90])
+    center: Optional[Tuple[float, float, int]]
+
+    class Config:
+        """Model configuration."""
+
+        extra = "ignore"

--- a/cogeo_mosaic/overviews.py
+++ b/cogeo_mosaic/overviews.py
@@ -44,7 +44,7 @@ def _tile(
 
 def _get_info(src_path: str) -> Dict:
     with COGReader(src_path) as cog:
-        info = cog.info()
+        info = cog.info().dict()
         info["nodata_value"] = cog.dataset.nodata
 
     return info

--- a/docs/advanced/readers.md
+++ b/docs/advanced/readers.md
@@ -10,13 +10,15 @@ Set by default to `rio_tiler.io.COGReader`, or to `rio_tiler.io.STACReader` for 
 ```python
 from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.backends import MosaicBackend
+from rio_tiler.models import ImageData
 
 dataset = ["1.tif", "2.tif"]
 mosaic_definition = MosaicJSON.from_urls(dataset)
 
 # Create a mosaic object in memory
 with MosaicBackend(None, mosaid_def=mosaic_definition, reader=COGReader) as mosaic:
-    tile, mask = mosaic.tile(1, 1, 1)
+    img, assets_used = mosaic.tile(1, 1, 1)
+    assert isinstance(img, ImageData)
 
 # By default the STACbackend will store the Item url as assets, but STACReader (default reader) will know how to read them.
 with MosaicBackend(
@@ -25,7 +27,7 @@ with MosaicBackend(
   7,  # minzoom
   12, # maxzoom
 ) as mosaic:
-    tile, mask = mosaic.tile(1, 1, 1, assets="red")
+    img, assets_used = mosaic.tile(1, 1, 1, assets="red")
 ```
 
 Let's use a custom accessor to save some specific assets url in the mosaic
@@ -44,5 +46,5 @@ with MosaicBackend(
   reader=COGReader,
   backend_options={"accessor": accessor},
 ) as mosaic:
-    tile, mask = mosaic.tile(1, 1, 1)
+    img, assets_used = mosaic.tile(1, 1, 1)
 ```

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -88,7 +88,7 @@ with MosaicBackend("s3://mybucket/amosaic.json") as mosaic:
 from cogeo_mosaic.backends import MosaicBackend
 
 with MosaicBackend("s3://mybucket/amosaic.json") as mosaic:
-    tile, mask = mosaic.tile(1, 2, 3)
+    img, assets_used = mosaic.tile(1, 2, 3)
 ```
 
 ##### Write
@@ -120,7 +120,7 @@ from cogeo_mosaic.backends import MosaicBackend
 mosaic_definition = MosaicJSON.from_urls(["1.tif", "2.tif"])
 
 with MosaicBackend(None, mosaic_def=mosaicdata) as mosaic:
-    tile, mask = mosaic.tile(1, 2, 3)
+    img, assets_used = mosaic.tile(1, 2, 3)
 ```
 
 # Image Order

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ inst_reqs = [
     "rasterio",
     "requests",
     "rio-cogeo>=2.0",
-    "rio-tiler>=2.0.0b17",
+    "rio-tiler>=2.0.0rc1",
     "cachetools",
     "supermercado",
 ]

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -53,11 +53,11 @@ def test_file_backend():
 
         info = mosaic.info()
         assert not info["quadkeys"]
-        assert list(info) == [
+        assert list(info.dict()) == [
             "bounds",
             "center",
-            "maxzoom",
             "minzoom",
+            "maxzoom",
             "name",
             "quadkeys",
         ]
@@ -65,7 +65,7 @@ def test_file_backend():
         info = mosaic.info(quadkeys=True)
         assert info["quadkeys"]
 
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -96,7 +96,7 @@ def test_file_backend():
     with MosaicBackend(mosaic_jsonV1) as mosaic:
         assert isinstance(mosaic, FileBackend)
         assert mosaic.quadkey_zoom == 7
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -161,7 +161,7 @@ def test_http_backend(requests):
             == "f39f05644731addf1d183fa094ff6478900a27912ad035ef570231b1"
         )
         assert mosaic.quadkey_zoom == 7
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -221,7 +221,7 @@ def test_s3_backend(session):
             == "f39f05644731addf1d183fa094ff6478900a27912ad035ef570231b1"
         )
         assert mosaic.quadkey_zoom == 7
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -396,7 +396,7 @@ def test_dynamoDB_backend(client):
         assert mosaic._backend_name == "AWS DynamoDB"
         assert isinstance(mosaic, DynamoDBBackend)
         assert mosaic.quadkey_zoom == 7
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -410,11 +410,11 @@ def test_dynamoDB_backend(client):
 
         info = mosaic.info()
         assert not info["quadkeys"]
-        assert list(info) == [
+        assert list(info.dict()) == [
             "bounds",
             "center",
-            "maxzoom",
             "minzoom",
+            "maxzoom",
             "name",
             "quadkeys",
         ]
@@ -470,7 +470,7 @@ def test_stac_backend(post):
         assert isinstance(mosaic, STACBackend)
         assert post.call_count == 1
         assert mosaic.quadkey_zoom == 8
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -502,7 +502,7 @@ def test_stac_backend(post):
         assert isinstance(mosaic, STACBackend)
         assert post.call_count == 2
         assert mosaic.quadkey_zoom == 8
-        assert list(mosaic.metadata.keys()) == [
+        assert list(mosaic.metadata.dict(exclude_none=True).keys()) == [
             "mosaicjson",
             "version",
             "minzoom",
@@ -657,11 +657,11 @@ def test_BaseReader():
             mosaic.part()
 
         info = mosaic.info()
-        assert list(info) == [
+        assert list(info.dict()) == [
             "bounds",
             "center",
-            "maxzoom",
             "minzoom",
+            "maxzoom",
             "name",
             "quadkeys",
         ]


### PR DESCRIPTION
This PR does:
- add rio-tiler ImageData output type
- add output models from `info()` and `metadata()` methods


status:  waiting for https://github.com/cogeotiff/rio-tiler/pull/297 to be published