### PR TITLE
make boto3 optional

### DIFF
--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -11,10 +11,8 @@ from typing import Any, Dict, List, Sequence
 from urllib.parse import urlparse
 
 import attr
-import boto3
 import click
 import mercantile
-from boto3.dynamodb.conditions import Key
 from botocore.exceptions import ClientError
 from cachetools import TTLCache, cached
 from cachetools.keys import hashkey
@@ -31,6 +29,13 @@ from cogeo_mosaic.errors import (
 from cogeo_mosaic.logger import logger
 from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.utils import bbox_union
+
+try:
+    import boto3
+    from boto3.dynamodb.conditions import Key
+except ImportError:  # pragma: nocover
+    boto3 = None  # type: ignore
+    Key = None  # type: ignore
 
 
 @attr.s
@@ -55,6 +60,8 @@ class DynamoDBBackend(BaseBackend):
         dynamodb:///{table_name}:{mosaic_name}
 
         """
+        assert boto3 is not None, "'boto3' must be installed to use DynamoDBBackend"
+
         logger.debug(f"Using DynamoDB backend: {self.path}")
 
         if not re.match(

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ with open("README.md") as f:
 # Runtime requirements.
 inst_reqs = [
     "attrs",
-    "boto3",
     "mercantile",
     "morecantile",
     "pygeos>=0.7",
@@ -22,6 +21,7 @@ inst_reqs = [
 ]
 
 extra_reqs = {
+    "aws": ["boto3"],
     "test": ["pytest", "pytest-cov"],
     "dev": ["pytest", "pytest-cov", "pre-commit"],
     "docs": ["mkdocs", "mkdocs-material", "pygments", "mkapi"],

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py36,py37,py38
 
 [testenv]
-extras = test
+extras = test,aws
 commands=
     python -m pytest --cov cogeo_mosaic --cov-report xml --cov-report term-missing --ignore=venv
 deps=


### PR DESCRIPTION
ref #142 

Just makes things a bit cleaner if we ever want to add more backends and providers. 

Note: boto3 is already a dependency in rio-tiler (might change) is technically boto3 will always be present 