### PR TITLE
[WIP] new access mode

### DIFF
--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -31,13 +31,13 @@ class BaseBackend(BaseReader):
     Attributes:
         path (str): mosaic path.
         mode (str, optional): Access mode. Available modes are: r (read-only), r+ (read and write), w (write). Defaults to read-only `r`.
-        reader (rio_tiler.io.BaseReader): Dataset reader. Defaults to rio_tiler.io.COGReader.
+        reader (rio_tiler.io.BaseReader): Dataset reader. Defaults to `rio_tiler.io.COGReader`.
         reader_options (dict): Options to forward to the reader config.
         backend_options (dict): Global backend options.
         tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. **READ ONLY attribute**. Defaults to `WebMercatorQuad`.
-        bbox (tuple): mosaic bounds (left, bottom, right, top). **READ ONLY attribute**. Defaults to TMS's bounds.
-        minzoom (int): mosaic Min zoom level. **READ ONLY attribute**. Defaults to TMS's minzoom.
-        maxzoom (int): mosaic Max zoom level. **READ ONLY attribute**. Defaults to TMS's maxzoom.
+        bbox (tuple): mosaic bounds (left, bottom, right, top). **READ ONLY attribute**. Defaults to `(-180, -90, 180, 90)`.
+        minzoom (int): mosaic Min zoom level. **READ ONLY attribute**. Defaults to `0`.
+        maxzoom (int): mosaic Max zoom level. **READ ONLY attribute**. Defaults to `30`
         mosaic_def (MosaicJSON): mosaicJSON document. **READ ONLY attribute**.
 
     """

--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -53,10 +53,10 @@ class BaseBackend(BaseReader):
     tms: TileMatrixSet = attr.ib(init=False, default=WEB_MERCATOR_TMS)
 
     bounds: Tuple[float, float, float, float] = attr.ib(
-        init=False, default=WEB_MERCATOR_TMS.bbox
+        init=False, default=(-180, -90, 180, 90)
     )
-    minzoom: int = attr.ib(init=False, default=WEB_MERCATOR_TMS.minzoom)
-    maxzoom: int = attr.ib(init=False, default=WEB_MERCATOR_TMS.maxzoom)
+    minzoom: int = attr.ib(init=False, default=0)
+    maxzoom: int = attr.ib(init=False, default=30)
 
     mosaic_def: MosaicJSON = attr.ib(init=False)
 

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -1,6 +1,7 @@
 """cogeo-mosaic File backend."""
 
 import json
+import pathlib
 
 import attr
 from cachetools import TTLCache, cached
@@ -9,7 +10,7 @@ from cachetools.keys import hashkey
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import _compress_gz_json, _decompress_gz
 from cogeo_mosaic.cache import cache_config
-from cogeo_mosaic.errors import _FILE_EXCEPTIONS, MosaicError
+from cogeo_mosaic.errors import _FILE_EXCEPTIONS, MosaicError, MosaicExistsError
 from cogeo_mosaic.mosaic import MosaicJSON
 
 
@@ -19,15 +20,21 @@ class FileBackend(BaseBackend):
 
     _backend_name = "File"
 
-    def write(self, mosaic: MosaicJSON, gzip: bool = None):
+    def write(self, mosaic: MosaicJSON, overwrite: bool = False, gzip: bool = None):
         """Write mosaicjson document to a file."""
         if self.mode == "r":
             raise ValueError(
                 "Can only write a mosaic opened in 'r+' or 'w' mode, not r."
             )
 
-        body = mosaic.dict(exclude_none=True)
+        if not overwrite and pathlib.Path(self.path).exists():
+            raise MosaicExistsError("Mosaic file already exist, use `overwrite=True`.")
+
+        if not isinstance(mosaic, MosaicJSON):
+            mosaic = MosaicJSON(**dict(mosaic))
+
         with open(self.path, "wb") as f:
+            body = mosaic.dict(exclude_none=True)
             try:
                 if gzip or (gzip is None and self.path.endswith(".gz")):
                     f.write(_compress_gz_json(body))
@@ -36,6 +43,8 @@ class FileBackend(BaseBackend):
             except Exception as e:
                 exc = _FILE_EXCEPTIONS.get(e, MosaicError)  # type: ignore
                 raise exc(str(e)) from e
+
+        self.mosaic_def = mosaic
 
     @cached(
         TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -21,6 +21,11 @@ class FileBackend(BaseBackend):
 
     def write(self, mosaic: MosaicJSON, gzip: bool = None):
         """Write mosaicjson document to a file."""
+        if self.mode == "r":
+            raise ValueError(
+                "Can only write a mosaic opened in 'r+' or 'w' mode, not r."
+            )
+
         body = mosaic.dict(exclude_none=True)
         with open(self.path, "wb") as f:
             try:

--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -1,7 +1,6 @@
 """cogeo-mosaic File backend."""
 
 import json
-import os
 
 import attr
 from cachetools import TTLCache, cached
@@ -10,7 +9,7 @@ from cachetools.keys import hashkey
 from cogeo_mosaic.backends.base import BaseBackend
 from cogeo_mosaic.backends.utils import _compress_gz_json, _decompress_gz
 from cogeo_mosaic.cache import cache_config
-from cogeo_mosaic.errors import _FILE_EXCEPTIONS, MosaicError, MosaicExistsError
+from cogeo_mosaic.errors import _FILE_EXCEPTIONS, MosaicError
 from cogeo_mosaic.mosaic import MosaicJSON
 
 
@@ -20,12 +19,9 @@ class FileBackend(BaseBackend):
 
     _backend_name = "File"
 
-    def write(self, overwrite: bool = False, gzip: bool = None):
+    def write(self, mosaic: MosaicJSON, gzip: bool = None):
         """Write mosaicjson document to a file."""
-        if not overwrite and os.path.exists(self.path):
-            raise MosaicExistsError("Mosaic file already exist, use `overwrite=True`.")
-
-        body = self.mosaic_def.dict(exclude_none=True)
+        body = mosaic.dict(exclude_none=True)
         with open(self.path, "wb") as f:
             try:
                 if gzip or (gzip is None and self.path.endswith(".gz")):

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -42,18 +42,34 @@ class S3Backend(BaseBackend):
         self.client = self.client or boto3_session().client("s3")
         super().__attrs_post_init__()
 
-    def write(self, overwrite: bool = False, gzip: bool = None, **kwargs: Any):
+    def write(
+        self,
+        mosaic: MosaicJSON,
+        overwrite: bool = False,
+        gzip: bool = None,
+        **kwargs: Any,
+    ):
         """Write mosaicjson document to AWS S3."""
-        mosaic_doc = self.mosaic_def.dict(exclude_none=True)
-        if gzip or (gzip is None and self.key.endswith(".gz")):
-            body = _compress_gz_json(mosaic_doc)
-        else:
-            body = json.dumps(mosaic_doc).encode("utf-8")
+        if self.mode == "r":
+            raise ValueError(
+                "Can only write a mosaic opened in 'r+' or 'w' mode, not r."
+            )
 
         if not overwrite and self._head_object(self.key, self.bucket):
             raise MosaicExistsError("Mosaic file already exist, use `overwrite=True`.")
 
+        if not isinstance(mosaic, MosaicJSON):
+            mosaic = MosaicJSON(**dict(mosaic))
+
+        body_dict = mosaic.dict(exclude_none=True)
+        if gzip or (gzip is None and self.key.endswith(".gz")):
+            body = _compress_gz_json(body_dict)
+        else:
+            body = json.dumps(body_dict).encode("utf-8")
+
         self._put_object(self.key, self.bucket, body, **kwargs)
+
+        self.mosaic_def = mosaic
 
     @cached(
         TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),

--- a/cogeo_mosaic/backends/web.py
+++ b/cogeo_mosaic/backends/web.py
@@ -24,14 +24,15 @@ class HttpBackend(BaseBackend):
     """Http/Https Backend Adapter"""
 
     _backend_name = "HTTP"
+    _available_modes = ["r"]
 
-    def write(self):
+    def write(self, mosaic: MosaicJSON, overwrite: bool = False):
         """Write mosaicjson document."""
-        raise NotImplementedError
+        raise NotImplementedError("HttpBackend is a read-only backend")
 
     def update(self, *args, **kwargs: Any):
         """Update the mosaicjson document."""
-        raise NotImplementedError
+        raise NotImplementedError("HttpBackend is a read-only backend")
 
     @cached(
         TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -97,8 +97,8 @@ def create(
         mosaicjson.attribution = attribution
 
     if output:
-        with MosaicBackend(output, mosaic_def=mosaicjson) as mosaic:
-            mosaic.write(overwrite=True)
+        with MosaicBackend(output, mode="w") as mosaic:
+            mosaic.write(mosaicjson, overwrite=True)
     else:
         click.echo(mosaicjson.json(exclude_none=True))
 
@@ -112,8 +112,8 @@ def upload(file, url):
     """Upload mosaic definition file."""
     mosaicjson = json.load(file)
 
-    with MosaicBackend(url, mosaic_def=mosaicjson) as mosaic:
-        mosaic.write(overwrite=True)
+    with MosaicBackend(url, mode="w") as mosaic:
+        mosaic.write(mosaicjson, overwrite=True)
 
 
 @cogeo_cli.command(
@@ -177,8 +177,8 @@ def create_from_features(
         mosaicjson.attribution = attribution
 
     if output:
-        with MosaicBackend(output, mosaic_def=mosaicjson) as mosaic:
-            mosaic.write(overwrite=True)
+        with MosaicBackend(output, mode="w") as mosaic:
+            mosaic.write(mosaicjson, overwrite=True)
     else:
         click.echo(mosaicjson.json(exclude_none=True))
 
@@ -210,7 +210,7 @@ def update(input_files, input_mosaic, min_tile_cover, add_first, threads, quiet)
     """Update mosaic definition file."""
     input_files = input_files.read().splitlines()
     features = get_footprints(input_files, max_threads=threads)
-    with MosaicBackend(input_mosaic) as mosaic:
+    with MosaicBackend(input_mosaic, mode="r+") as mosaic:
         mosaic.update(
             features,
             add_first=add_first,
@@ -257,7 +257,7 @@ def footprint(input_files, output, threads, quiet):
 )
 def info(input, to_json):
     """Return info about the mosaic."""
-    with MosaicBackend(input) as mosaic:
+    with MosaicBackend(input, mode="r") as mosaic:
         _info = {
             "Path": input,
             "Backend": mosaic._backend_name,
@@ -339,7 +339,7 @@ def info(input, to_json):
 def to_geojson(input, collect):
     """Read MosaicJSON document and create GeoJSON features."""
     features = []
-    with MosaicBackend(input) as mosaic:
+    with MosaicBackend(input, mode="r") as mosaic:
         for qk, assets in mosaic.mosaic_def.tiles.items():
             tile = mercantile.quadkey_to_tile(qk)
 

--- a/setup.py
+++ b/setup.py
@@ -8,15 +8,14 @@ with open("README.md") as f:
 # Runtime requirements.
 inst_reqs = [
     "attrs",
+    "cachetools",
     "mercantile",
-    "morecantile",
-    "pygeos>=0.7",
+    "morecantile>=2.1,<2.2",
     "pydantic",
-    "requests",
+    "pygeos>=0.7",
     "rasterio",
     "requests",
-    "rio-tiler>=2.0.0rc4,<2.1",
-    "cachetools",
+    "rio-tiler>=2.0,<2.1",
     "supermercado",
 ]
 


### PR DESCRIPTION
closes #156 

This PR refactor the way Mosaic Backends inputs works. 

```python
# Write Mosaic
### before 
with FileBackend("my_path.json.gz", mosaic_def=mymosaic) as mosaic:
    mosaic.write()

### now
with FileBackend("my_path.json.gz", mode="w") as mosaic:
    mosaic.write(mymosaic)
```

```python
# Read Mosaic
### before
with FileBackend("my_path.json.gz") as mosaic:
     ...

### now
with FileBackend("my_path.json.gz", mode="r") as mosaic: # mode is optional because we default to 'r'
     ...
```

```python
# Update Mosaic
### before
with FileBackend("my_path.json.gz") as mosaic:
     mosaic.update(anothermosaic)

### now
with FileBackend("my_path.json.gz", mode="r+") as mosaic:
         mosaic.update(anothermosaic)
```
