### PR TITLE
new access mode

### DIFF
--- a/cogeo_mosaic/backends/base.py
+++ b/cogeo_mosaic/backends/base.py
@@ -2,6 +2,7 @@
 
 import abc
 import itertools
+from copy import deepcopy
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Type
 
 import attr
@@ -18,18 +19,57 @@ from rio_tiler.tasks import create_tasks, filter_tasks
 
 from cogeo_mosaic.backends.utils import find_quadkeys, get_hash
 from cogeo_mosaic.cache import cache_config
-from cogeo_mosaic.errors import NoAssetFoundError
+from cogeo_mosaic.errors import NoAssetFoundError, UnsupportedOperation
 from cogeo_mosaic.models import Info, Metadata
 from cogeo_mosaic.mosaic import MosaicJSON
 from cogeo_mosaic.utils import bbox_union
 
 
+def update_zoom_and_bounds(instance, attribute, value):
+    """Update Zooms and Bounds attribute when mosaic_def is set."""
+    instance.minzoom = value.minzoom
+    instance.maxzoom = value.maxzoom
+    instance.bounds = value.bounds
+    return value
+
+
+def mode_validator(instance, attribute, value):
+    """Validate mode."""
+    if value not in instance._available_modes:
+        raise ValueError(
+            f"Invalid '{value}' mode. MUST be one of {instance._available_modes}."
+        )
+
+    if "r" in value:
+        instance._readable = True
+
+    elif "w" in value:
+        instance._writable = True
+
+    if "+" in value:
+        instance._writable = True
+
+
 @attr.s
 class BaseBackend(BaseReader):
-    """Base Class for cogeo-mosaic backend storage."""
+    """Base Class for cogeo-mosaic backend storage.
+
+    Attributes:
+        path (str): mosaic path.
+        mode (str, optional): Access mode. Available modes are: r (read-only), r+ (read and write), w (write). Defaults to read-only `r`.
+        reader (rio_tiler.io.BaseReader): Dataset reader. Defaults to `rio_tiler.io.COGReader`.
+        reader_options (dict): Options to forward to the reader config.
+        backend_options (dict): Global backend options.
+        tms (morecantile.TileMatrixSet, optional): TileMatrixSet grid definition. **READ ONLY attribute**. Defaults to `WebMercatorQuad`.
+        bbox (tuple): mosaic bounds (left, bottom, right, top). **READ ONLY attribute**. Defaults to `(-180, -90, 180, 90)`.
+        minzoom (int): mosaic Min zoom level. **READ ONLY attribute**. Defaults to `0`.
+        maxzoom (int): mosaic Max zoom level. **READ ONLY attribute**. Defaults to `30`
+        mosaic_def (MosaicJSON, optional): mosaicJSON document. **READ ONLY attribute**.
+
+    """
 
     path: str = attr.ib()
-    mosaic_def: MosaicJSON = attr.ib(default=None)
+    mode: str = attr.ib(default="r", validator=mode_validator)
     reader: Type[BaseReader] = attr.ib(default=COGReader)
     reader_options: Dict = attr.ib(factory=dict)
     backend_options: Dict = attr.ib(factory=dict)
@@ -38,57 +78,30 @@ class BaseBackend(BaseReader):
     # works with WebMercator (mercantile) for now.
     tms: TileMatrixSet = attr.ib(init=False, default=WEB_MERCATOR_TMS)
 
-    _backend_name: str
-    _file_byte_size: Optional[int] = 0
+    bounds: Tuple[float, float, float, float] = attr.ib(
+        init=False, default=(-180, -90, 180, 90)
+    )
+    minzoom: int = attr.ib(init=False, default=0)
+    maxzoom: int = attr.ib(init=False, default=30)
 
-    @mosaic_def.validator
-    def _check_mosaic_def(self, attribute, value):
-        if value is not None:
-            self.mosaic_def = MosaicJSON(**dict(value))
+    mosaic_def: MosaicJSON = attr.ib(init=False, on_setattr=update_zoom_and_bounds)  # type: ignore
+
+    _backend_name: str
+    _available_modes: List[str] = ["r", "r+", "w"]
+    _readable: bool = False
+    _writable: bool = False
+    _file_byte_size: Optional[int] = 0
 
     def __attrs_post_init__(self):
         """Post Init: if not passed in init, try to read from self.path."""
-        self.mosaic_def = self.mosaic_def or self._read(**self.backend_options)
+        if self._readable:
+            self.mosaic_def = self._read(**self.backend_options)
 
-        self.minzoom = self.mosaic_def.minzoom
-        self.maxzoom = self.mosaic_def.maxzoom
-        self.bounds = self.mosaic_def.bounds
-
-    @property
-    def center(self):
-        """Return center from the mosaic definition."""
-        return self.mosaic_def.center
-
-    def info(self, quadkeys: bool = False) -> Info:  # type: ignore
-        """Mosaic info."""
-        return Info(
-            bounds=self.mosaic_def.bounds,
-            center=self.mosaic_def.center,
-            maxzoom=self.mosaic_def.maxzoom,
-            minzoom=self.mosaic_def.minzoom,
-            name=self.mosaic_def.name if self.mosaic_def.name else "mosaic",
-            quadkeys=[] if not quadkeys else self._quadkeys,
-        )
-
-    @property
-    def _quadkeys(self) -> List[str]:
-        """Return the list of quadkey tiles."""
-        return list(self.mosaic_def.tiles)
-
-    def stats(self):
-        """PlaceHolder for BaseReader.stats."""
-        raise NotImplementedError
-
-    @property
-    def metadata(self) -> Metadata:  # type: ignore
-        """Retrieve Mosaic metadata
-
-        Returns
-        -------
-        MosaicJSON as dict without `tiles` key.
-
-        """
-        return Metadata(**self.mosaic_def.dict())
+    ############################################################################
+    # Read Method/Properties
+    @abc.abstractmethod
+    def _read(self) -> MosaicJSON:
+        """Fetch mosaic definition"""
 
     def assets_for_tile(self, x: int, y: int, z: int) -> List[str]:
         """Retrieve assets for tile."""
@@ -111,6 +124,17 @@ class BaseBackend(BaseReader):
             itertools.chain.from_iterable(
                 [self.mosaic_def.tiles.get(qk, []) for qk in quadkeys]
             )
+        )
+
+    def info(self, quadkeys: bool = False) -> Info:  # type: ignore
+        """Mosaic info."""
+        return Info(
+            bounds=self.mosaic_def.bounds,
+            center=self.mosaic_def.center,
+            maxzoom=self.mosaic_def.maxzoom,
+            minzoom=self.mosaic_def.minzoom,
+            name=self.mosaic_def.name if self.mosaic_def.name else "mosaic",
+            quadkeys=[] if not quadkeys else self._quadkeys,
         )
 
     def tile(  # type: ignore
@@ -158,6 +182,79 @@ class BaseBackend(BaseReader):
             )
         ]
 
+    @property
+    def _quadkeys(self) -> List[str]:
+        """Return the list of quadkey tiles."""
+        return list(self.mosaic_def.tiles)
+
+    @property
+    def center(self):
+        """Return center from the mosaic definition."""
+        return self.mosaic_def.center
+
+    @property
+    def metadata(self) -> Metadata:  # type: ignore
+        """Return Mosaic metadata"""
+        return Metadata(**self.mosaic_def.dict())
+
+    @property
+    def mosaicid(self) -> str:
+        """Return sha224 id of the mosaicjson document."""
+        return get_hash(**self.mosaic_def.dict(exclude_none=True))
+
+    @property
+    def quadkey_zoom(self) -> int:
+        """Return Quadkey zoom property."""
+        return self.mosaic_def.quadkey_zoom or self.mosaic_def.minzoom
+
+    ############################################################################
+    # Write methods
+    @abc.abstractmethod
+    def write(self, mosaic: MosaicJSON, overwrite: bool = True):
+        """Upload new MosaicJSON to backend."""
+
+    def update(
+        self,
+        features: Sequence[Dict],
+        add_first: bool = True,
+        quiet: bool = False,
+        **kwargs,
+    ):
+        """Update existing MosaicJSON on backend."""
+        if not self._writable:
+            raise UnsupportedOperation("not writable")
+
+        mosaic = deepcopy(self.mosaic_def)
+        new_mosaic = MosaicJSON.from_features(
+            features,
+            mosaic.minzoom,
+            mosaic.maxzoom,
+            quadkey_zoom=self.quadkey_zoom,
+            quiet=quiet,
+            **kwargs,
+        )
+
+        # Update Tiles
+        for quadkey, new_assets in new_mosaic.tiles.items():
+            tile = mercantile.quadkey_to_tile(quadkey)
+            assets = self.assets_for_tile(*tile)
+            assets = [*new_assets, *assets] if add_first else [*assets, *new_assets]
+            mosaic.tiles[quadkey] = assets
+
+        # Update Metadata
+        bounds = bbox_union(new_mosaic.bounds, mosaic.bounds)
+        mosaic._increase_version()
+        mosaic.bounds = bounds
+        mosaic.center = (
+            (bounds[0] + bounds[2]) / 2,
+            (bounds[1] + bounds[3]) / 2,
+            mosaic.minzoom,
+        )
+
+        self.write(mosaic, overwrite=True)
+
+    ############################################################################
+    # Not Implemented methods
     def preview(self):
         """PlaceHolder for BaseReader.preview."""
         raise NotImplementedError
@@ -170,61 +267,6 @@ class BaseBackend(BaseReader):
         """PlaceHolder for BaseReader.feature."""
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def _read(self) -> MosaicJSON:
-        """Fetch mosaic definition"""
-
-    @property
-    def mosaicid(self) -> str:
-        """Return sha224 id of the mosaicjson document."""
-        return get_hash(**self.mosaic_def.dict(exclude_none=True))
-
-    @property
-    def quadkey_zoom(self) -> int:
-        """Return Quadkey zoom property."""
-        return self.mosaic_def.quadkey_zoom or self.mosaic_def.minzoom
-
-    @abc.abstractmethod
-    def write(self, overwrite: bool = True):
-        """Upload new MosaicJSON to backend."""
-
-    def update(
-        self,
-        features: Sequence[Dict],
-        add_first: bool = True,
-        quiet: bool = False,
-        **kwargs,
-    ):
-        """Update existing MosaicJSON on backend."""
-        new_mosaic = MosaicJSON.from_features(
-            features,
-            self.mosaic_def.minzoom,
-            self.mosaic_def.maxzoom,
-            quadkey_zoom=self.quadkey_zoom,
-            quiet=quiet,
-            **kwargs,
-        )
-
-        for quadkey, new_assets in new_mosaic.tiles.items():
-            tile = mercantile.quadkey_to_tile(quadkey)
-            assets = self.assets_for_tile(*tile)
-            assets = [*new_assets, *assets] if add_first else [*assets, *new_assets]
-
-            # add custom sorting algorithm (e.g based on path name)
-            self.mosaic_def.tiles[quadkey] = assets
-
-        bounds = bbox_union(new_mosaic.bounds, self.mosaic_def.bounds)
-
-        self.mosaic_def._increase_version()
-        self.mosaic_def.bounds = bounds
-        self.mosaic_def.center = (
-            (bounds[0] + bounds[2]) / 2,
-            (bounds[1] + bounds[3]) / 2,
-            self.mosaic_def.minzoom,
-        )
-
-        # We only write if path is set
-        if self.path:
-            self.write(overwrite=True)
-
-        return
+    def stats(self):
+        """PlaceHolder for BaseReader.stats."""
+        raise NotImplementedError

--- a/cogeo_mosaic/backends/web.py
+++ b/cogeo_mosaic/backends/web.py
@@ -5,7 +5,7 @@ lib module
 """
 
 import json
-from typing import Any
+from typing import Dict, List, Sequence
 
 import attr
 import requests
@@ -24,14 +24,21 @@ class HttpBackend(BaseBackend):
     """Http/Https Backend Adapter"""
 
     _backend_name = "HTTP"
+    _available_modes: List[str] = ["r"]
 
-    def write(self):
+    def write(self, mosaic: MosaicJSON, overwrite: bool = True):
         """Write mosaicjson document."""
-        raise NotImplementedError
+        raise NotImplementedError("HttpBackend is a Read-Only backend.")
 
-    def update(self, *args, **kwargs: Any):
+    def update(
+        self,
+        features: Sequence[Dict],
+        add_first: bool = True,
+        quiet: bool = False,
+        **kwargs,
+    ):
         """Update the mosaicjson document."""
-        raise NotImplementedError
+        raise NotImplementedError("HttpBackend is a Read-Only backend.")
 
     @cached(
         TTLCache(maxsize=cache_config.maxsize, ttl=cache_config.ttl),

--- a/cogeo_mosaic/errors.py
+++ b/cogeo_mosaic/errors.py
@@ -25,6 +25,10 @@ class MosaicExistsError(MosaicError):
     """MosaicJSON already exists."""
 
 
+class UnsupportedOperation(MosaicError):
+    """MosaicBackend Unsupported Operation."""
+
+
 _HTTP_EXCEPTIONS = {
     401: MosaicAuthError,
     403: MosaicAuthError,

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -97,8 +97,8 @@ def create(
         mosaicjson.attribution = attribution
 
     if output:
-        with MosaicBackend(output, mosaic_def=mosaicjson) as mosaic:
-            mosaic.write(overwrite=True)
+        with MosaicBackend(output, mode="w") as mosaic:
+            mosaic.write(mosaicjson, overwrite=True)
     else:
         click.echo(mosaicjson.json(exclude_none=True))
 
@@ -112,8 +112,8 @@ def upload(file, url):
     """Upload mosaic definition file."""
     mosaicjson = json.load(file)
 
-    with MosaicBackend(url, mosaic_def=mosaicjson) as mosaic:
-        mosaic.write(overwrite=True)
+    with MosaicBackend(url, mode="w") as mosaic:
+        mosaic.write(mosaicjson, overwrite=True)
 
 
 @cogeo_cli.command(
@@ -177,8 +177,8 @@ def create_from_features(
         mosaicjson.attribution = attribution
 
     if output:
-        with MosaicBackend(output, mosaic_def=mosaicjson) as mosaic:
-            mosaic.write(overwrite=True)
+        with MosaicBackend(output, mode="w") as mosaic:
+            mosaic.write(mosaicjson, overwrite=True)
     else:
         click.echo(mosaicjson.json(exclude_none=True))
 
@@ -210,7 +210,7 @@ def update(input_files, input_mosaic, min_tile_cover, add_first, threads, quiet)
     """Update mosaic definition file."""
     input_files = input_files.read().splitlines()
     features = get_footprints(input_files, max_threads=threads)
-    with MosaicBackend(input_mosaic) as mosaic:
+    with MosaicBackend(input_mosaic, mode="r+") as mosaic:
         mosaic.update(
             features,
             add_first=add_first,


### PR DESCRIPTION
closes #156 

The PR change the way users can write mosaicJSON using the backends. The changes also add `access mode` to the backend object to better define read/write modes. 

```python
# Write Mosaic
### before 
with FileBackend("my_path.json.gz", mosaic_def=mymosaic) as mosaic:
    mosaic.write()

### now
with FileBackend("my_path.json.gz", mode="w") as mosaic:
    mosaic.write(mymosaic)
```

For most of the backend, access mode are either:
- `r`: read-only
- `r+`: read-update
- `w`: write

All backends must have the `_available_modes` variable set to indicate which mode are supported:

https://github.com/developmentseed/cogeo-mosaic/blob/7242abc8af39eb7eebb48db195a0cc7e029e8bc3/cogeo_mosaic/backends/web.py#L27

By default the backends are opened with `r` read-only mode. 



`mosaic_def` is now outside the `init` method (**breaking**) and must be provided using the `.write()` method (if the backend is opened in `w` mode.

cc @kylebarron 