### PR TITLE
reorder backend methods and raise error when backend is read-only

### DIFF
--- a/cogeo_mosaic/backends/file.py
+++ b/cogeo_mosaic/backends/file.py
@@ -1,7 +1,7 @@
 """cogeo-mosaic File backend."""
 
 import json
-import os
+import pathlib
 
 import attr
 from cachetools import TTLCache, cached
@@ -22,7 +22,7 @@ class FileBackend(BaseBackend):
 
     def write(self, overwrite: bool = False, gzip: bool = None):
         """Write mosaicjson document to a file."""
-        if not overwrite and os.path.exists(self.path):
+        if not overwrite and pathlib.Path(self.path).exists():
             raise MosaicExistsError("Mosaic file already exist, use `overwrite=True`.")
 
         body = self.mosaic_def.dict(exclude_none=True)

--- a/cogeo_mosaic/backends/s3.py
+++ b/cogeo_mosaic/backends/s3.py
@@ -44,14 +44,14 @@ class S3Backend(BaseBackend):
 
     def write(self, overwrite: bool = False, gzip: bool = None, **kwargs: Any):
         """Write mosaicjson document to AWS S3."""
+        if not overwrite and self._head_object(self.key, self.bucket):
+            raise MosaicExistsError("Mosaic file already exist, use `overwrite=True`.")
+
         mosaic_doc = self.mosaic_def.dict(exclude_none=True)
         if gzip or (gzip is None and self.key.endswith(".gz")):
             body = _compress_gz_json(mosaic_doc)
         else:
             body = json.dumps(mosaic_doc).encode("utf-8")
-
-        if not overwrite and self._head_object(self.key, self.bucket):
-            raise MosaicExistsError("Mosaic file already exist, use `overwrite=True`.")
 
         self._put_object(self.key, self.bucket, body, **kwargs)
 


### PR DESCRIPTION
This PR does:
- reorder methods within backends for better visibility
- remove `mosaic_def` in `__init__`  for read-only backends
```python
with HttpBackend(url, mosaic_def=mosaic): 
     pass
```
☝️ this will now raise a TypeError with mosaic_def not in init method. 

- add minzoom/maxzoom/bounds default for the backends (those are mandatory for the BaseReader but we never really set them. They are not set from the mosaicjson doc)