### PR TITLE
Remove empty strings from a list of input files

### DIFF
--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -77,7 +77,7 @@ def create(
     quiet,
 ):
     """Create mosaic definition file."""
-    input_files = input_files.read().strip().splitlines()
+    input_files = [file.strip() for file in input_files if file.strip()]
     mosaicjson = MosaicJSON.from_urls(
         input_files,
         minzoom=minzoom,

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -77,7 +77,7 @@ def create(
     quiet,
 ):
     """Create mosaic definition file."""
-    input_files = filter(None, input_files.read().splitlines())
+    input_files = input_files.read().strip().splitlines()
     mosaicjson = MosaicJSON.from_urls(
         input_files,
         minzoom=minzoom,

--- a/cogeo_mosaic/scripts/cli.py
+++ b/cogeo_mosaic/scripts/cli.py
@@ -77,7 +77,7 @@ def create(
     quiet,
 ):
     """Create mosaic definition file."""
-    input_files = input_files.read().splitlines()
+    input_files = filter(None, input_files.read().splitlines())
     mosaicjson = MosaicJSON.from_urls(
         input_files,
         minzoom=minzoom,


### PR DESCRIPTION
To clean up the output of `cogeo-mosaic` CLI.

```
$ cogeo-mosaic create -o mosaic.js list.txt
: No such file or directory
Get quadkey list for zoom: 10
Feed Quadkey index
```