### PR TITLE
add asset for bbox method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * update morecantile requirement to >= 3.0
 * update rio-tiler requirement to >= 3.0 and update Backend's properties
 * switch from `requests` to `httpx`
+* add `BaseBackend.assets_for_bbox()` method (https://github.com/developmentseed/cogeo-mosaic/pull/184)
 
 **breaking changes**
 

--- a/cogeo_mosaic/backends/dynamodb.py
+++ b/cogeo_mosaic/backends/dynamodb.py
@@ -212,8 +212,10 @@ class DynamoDBBackend(BaseBackend):
         mercator_tile = mercantile.Tile(x=x, y=y, z=z)
         quadkeys = find_quadkeys(mercator_tile, self.quadkey_zoom)
         return list(
-            itertools.chain.from_iterable(
-                [self._fetch_dynamodb(qk).get("assets", []) for qk in quadkeys]
+            dict.fromkeys(
+                itertools.chain.from_iterable(
+                    [self._fetch_dynamodb(qk).get("assets", []) for qk in quadkeys]
+                )
             )
         )
 

--- a/cogeo_mosaic/backends/sqlite.py
+++ b/cogeo_mosaic/backends/sqlite.py
@@ -273,7 +273,11 @@ class SQLiteBackend(BaseBackend):
         """Find assets."""
         mercator_tile = mercantile.Tile(x=x, y=y, z=z)
         quadkeys = find_quadkeys(mercator_tile, self.quadkey_zoom)
-        return list(itertools.chain.from_iterable([self._fetch(qk) for qk in quadkeys]))
+        return list(
+            dict.fromkeys(
+                itertools.chain.from_iterable([self._fetch(qk) for qk in quadkeys])
+            )
+        )
 
     @property
     def _quadkeys(self) -> List[str]:

--- a/cogeo_mosaic/backends/utils.py
+++ b/cogeo_mosaic/backends/utils.py
@@ -1,9 +1,7 @@
 """cogeo-mosaic.backends utility functions."""
 
 import hashlib
-import itertools
 import json
-import warnings
 import zlib
 from typing import Any, Dict, List
 
@@ -45,20 +43,6 @@ def find_quadkeys(mercator_tile: mercantile.Tile, quadkey_zoom: int) -> List[str
         return [mercantile.quadkey(*tile) for tile in mercator_tiles]
     else:
         return [mercantile.quadkey(*mercator_tile)]
-
-
-def get_assets_from_json(
-    tiles: Dict, quadkey_zoom: int, x: int, y: int, z: int
-) -> List[str]:
-    """Find assets."""
-    warnings.warn(
-        "get_assets_from_json will be deprecated in 3.0.0, and is now part of the backends.",
-        DeprecationWarning,
-    )
-
-    mercator_tile = mercantile.Tile(x=x, y=y, z=z)
-    quadkeys = find_quadkeys(mercator_tile, quadkey_zoom)
-    return list(itertools.chain.from_iterable([tiles.get(qk, []) for qk in quadkeys]))
 
 
 def _compress_gz_json(data: Dict) -> bytes:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -86,11 +86,18 @@ def test_file_backend():
             "bounds",
             "center",
         ]
+        # make sure we do not return asset twice (e.g for parent tile)
+        assert mosaic.assets_for_tile(18, 22, 6) == ["cog1.tif", "cog2.tif"]
+
         assert mosaic.assets_for_tile(150, 182, 9) == ["cog1.tif", "cog2.tif"]
         assert mosaic.assets_for_point(-73, 45) == ["cog1.tif", "cog2.tif"]
 
         assert len(mosaic.get_assets(150, 182, 9)) == 2
         assert len(mosaic.get_assets(147, 182, 12)) == 0
+
+        assert mosaic.assets_for_bbox(
+            -74.53125, 45.583289756006316, -73.828125, 46.07323062540836
+        ) == ["cog1.tif", "cog2.tif"]
 
     with MosaicBackend(mosaic_json) as mosaic:
         assert isinstance(mosaic, FileBackend)

--- a/tests/test_backends_utils.py
+++ b/tests/test_backends_utils.py
@@ -5,7 +5,6 @@ import os
 import re
 
 import mercantile
-import pytest
 
 from cogeo_mosaic.backends import utils
 
@@ -63,21 +62,3 @@ def test_find_quadkeys():
         "0302303303",
         "0302303302",
     ]
-
-
-def test_get_assets_from_json():
-    """Get assets list."""
-    qkz = mosaic_content.get("quadkey_zoom") or mosaic_content.get("minzoom")
-    with pytest.warns(DeprecationWarning):
-        assert (
-            len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 150, 182, 9))
-            == 2
-        )
-        assert (
-            len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 147, 182, 9))
-            == 1
-        )
-        assert (
-            len(utils.get_assets_from_json(mosaic_content["tiles"], qkz, 147, 182, 12))
-            == 0
-        )


### PR DESCRIPTION
closes #181 

This PR also fix an issue where `get_assets` would have returned assets multiple times. We now keep asset only once but keep the order.