### PR TITLE
Adds test for Mars TMS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dynamic = ["version", "readme"]
 dependencies = [
   "attrs",
   "morecantile>=3.1,<4.0",
+  "planetcantile",
   "shapely>=2.0b2,<3.0",
   "pydantic",
   "httpx",

--- a/tests/test_planetcantile.py
+++ b/tests/test_planetcantile.py
@@ -1,0 +1,61 @@
+"""test cogeo_mosaic.supermorecado submodule.
+
+Note: most of the test are adapted from https://github.com/mapbox/supermercado/blob/main/tests/test_cli.py
+"""
+
+import planetcantile
+
+from cogeo_mosaic.supermorecado import burnTiles
+
+MARS_EQUI_CLON_0 = planetcantile.planetary_tms.get('IAU_2015_49910')
+
+def test_burn_tile_center_point_roundtrip():
+    tile = [500000, 250000, 19]
+    print(planetcantile.__file__)
+    w, s, e, n = MARS_EQUI_CLON_0.bounds(*tile)
+
+    x = (e - w) / 2 + w
+    y = (n - s) / 2 + s
+    point_feature = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {"type": "Point", "coordinates": [x, y]},
+    }
+    assert burnTiles(tms=MARS_EQUI_CLON_0).burn([point_feature], 19).tolist() == [tile]
+
+
+def test_burn_tile_center_lines_roundtrip():
+    tiles = list(MARS_EQUI_CLON_0.children([0, 0, 0]))
+    bounds = (MARS_EQUI_CLON_0.bounds(*t) for t in tiles)
+    coords = (((e - w) / 2 + w, (n - s) / 2 + s) for w, s, e, n in bounds)
+
+    features = {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {"type": "LineString", "coordinates": list(coords)},
+    }
+
+    output_tiles = burnTiles(tms=MARS_EQUI_CLON_0).burn([features], 1).tolist()
+    assert sorted(output_tiles) == sorted([list(t) for t in tiles])
+
+
+def test_burn_cli_tile_shape():
+    tilegeom = {
+        "bbox": [-122.4755859375, 37.75334401310657, -122.431640625, 37.78808138412046],
+        "geometry": {
+            "coordinates": [
+                [
+                    [-122.4755859375, 37.75334401310657],
+                    [-122.4755859375, 37.78808138412046],
+                    [-122.431640625, 37.78808138412046],
+                    [-122.431640625, 37.75334401310657],
+                    [-122.4755859375, 37.75334401310657],
+                ]
+            ],
+            "type": "Polygon",
+        },
+        "id": "(1309, 3166, 13)",
+        "properties": {"title": "XYZ tile (1309, 3166, 13)"},
+        "type": "Feature",
+    }
+    assert burnTiles(tms=MARS_EQUI_CLON_0).burn([tilegeom], 13).tolist() == [[2618, 2376, 13], [2619, 2376, 13], [2618, 2377, 13], [2619, 2377, 13]]


### PR DESCRIPTION
This PR adds tests and support for a Mars planetary TMS. This test adds planetcantile as a dependency (to get the planetary TMS) included. That repo has a PR open [here](https://github.com/AndrewAnnex/planetcantile/pull/15) that adds the necessary `_geographic_crs` key to the TMS specifications. This ensures that the default (WGS84) that morecantile encodes is respected and that we do not get PROJ errors about missing transformations. So, [#15](https://github.com/AndrewAnnex/planetcantile/pull/15) needs to land before this lands.

Now, I am still seeing errors about incorrect negative dimensions in these tests. It looks like the bbox used in `find_extrema` is not properly populating.

Also, It is necessary to pass the TMS to the burntiles() calls in order to get the encoding working properly. So, clients are going to need to be able to pass in the TMS to cogeo-mosaic. I have not looked at if and how that happens yet. I assume that this passes in through TiTiler.