### PR TITLE
adds missing deps to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
   "rio-tiler>=6.0,<7.0",
   "supermorecado",
   "cachetools",
+  "numpy",
+  "click",
+  "cligj",
+  "click_plugins",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
the conda forge feedstock had noted some undeclared dependencies 