### PR TITLE
fix pagination of search results from stac-fastapi-pgstac

### DIFF
--- a/cogeo_mosaic/backends/stac.py
+++ b/cogeo_mosaic/backends/stac.py
@@ -206,15 +206,18 @@ def _fetch(  # noqa: C901
         # {"page": 1, "limit": 1000, "matched": 5671, "returned": 1000}
         # SAT-API META
         # {"page": 4, "limit": 100, "found": 350, "returned": 50}
+        # STAC api `numberMatched` and `numberReturned` fields in ItemCollection
+        # {"numberMatched": 10, "numberReturned": 5, "features": [...]}
         # otherwise we don't break early
         ctx = results.get("context", results.get("meta"))
-        matched = ctx.get("matched", ctx.get("found"))
+        returned = ctx.get("returned", results.get("numberReturned"))
+        matched = ctx.get("matched", ctx.get("found") or results.get("numberMatched"))
 
         logger.debug(json.dumps(ctx))
 
         # Check if there is more data to fetch
-        if matched:
-            if matched <= ctx["returned"]:
+        if None not in (matched, returned):
+            if matched <= returned:
                 break
 
             # We shouldn't fetch more item than matched

--- a/cogeo_mosaic/backends/stac.py
+++ b/cogeo_mosaic/backends/stac.py
@@ -216,7 +216,7 @@ def _fetch(  # noqa: C901
         logger.debug(json.dumps(ctx))
 
         # Check if there is more data to fetch
-        if None not in (matched, returned):
+        if matched is not None and returned is not None:
             if matched <= returned:
                 break
 

--- a/cogeo_mosaic/backends/stac.py
+++ b/cogeo_mosaic/backends/stac.py
@@ -206,22 +206,25 @@ def _fetch(  # noqa: C901
         # {"page": 1, "limit": 1000, "matched": 5671, "returned": 1000}
         # SAT-API META
         # {"page": 4, "limit": 100, "found": 350, "returned": 50}
+        # otherwise we don't break early
         ctx = results.get("context", results.get("meta"))
         matched = ctx.get("matched", ctx.get("found"))
 
         logger.debug(json.dumps(ctx))
+
         # Check if there is more data to fetch
-        if matched <= ctx["returned"]:
-            break
+        if matched:
+            if matched <= ctx["returned"]:
+                break
 
-        # We shouldn't fetch more item than matched
-        if len(features) == matched:
-            break
+            # We shouldn't fetch more item than matched
+            if len(features) == matched:
+                break
 
-        if len(features) > matched:
-            raise MosaicError(
-                "Something weird is going on, please open an issue in https://github.com/developmentseed/cogeo-mosaic"
-            )
+            if len(features) > matched:
+                raise MosaicError(
+                    "Something weird is going on, please open an issue in https://github.com/developmentseed/cogeo-mosaic"
+                )
         page += 1
 
         # https://github.com/radiantearth/stac-api-spec/blob/master/api-spec.md#paging-extension

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -887,8 +887,12 @@ def test_stac_search(post):
     post.reset_mock()
 
     post.side_effect = [
-        STACMockResponse({"features": [{"id": "1"}], "context": {"returned": 1, "limit": 1}}),
-        STACMockResponse({"features": [{"id": "2"}], "context": {"returned": 1, "limit": 1}})
+        STACMockResponse(
+            {"features": [{"id": "1"}], "context": {"returned": 1, "limit": 1}}
+        ),
+        STACMockResponse(
+            {"features": [{"id": "2"}], "context": {"returned": 1, "limit": 1}}
+        ),
     ]
     assert len(stac_search("https://a_stac.api/search", {}, max_items=2, limit=1)) == 2
     assert post.call_count == 2
@@ -896,8 +900,22 @@ def test_stac_search(post):
     stac_search.cache_clear()
 
     post.side_effect = [
-        STACMockResponse({"features": [{"id": "1"}], "numberMatched": 2, "numberReturned": 1, "context": {}}),
-        STACMockResponse({"features": [{"id": "2"}], "numberMatched": 2, "numberReturned": 1, "context": {}}),
+        STACMockResponse(
+            {
+                "features": [{"id": "1"}],
+                "numberMatched": 2,
+                "numberReturned": 1,
+                "context": {},
+            }
+        ),
+        STACMockResponse(
+            {
+                "features": [{"id": "2"}],
+                "numberMatched": 2,
+                "numberReturned": 1,
+                "context": {},
+            }
+        ),
     ]
     assert len(stac_search("https://a_stac.api/search", {}, max_items=2, limit=1)) == 2
     assert post.call_count == 2

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -884,6 +884,16 @@ def test_stac_search(post):
         ]
 
     assert len(stac_search("https://a_stac.api/search", {}, max_items=7)) == 7
+    post.reset_mock()
+
+    post.side_effect = [
+        STACMockResponse({"features": [{"id": "1"}], "context": {"returned": 1, "limit": 1}}),
+        STACMockResponse({"features": [{"id": "2"}], "context": {"returned": 1, "limit": 1}})
+    ]
+    assert len(stac_search("https://a_stac.api/search", {}, max_items=2, limit=1)) == 2
+    assert post.call_count == 2
+    post.reset_mock()
+
 
 
 def test_stac_accessor():

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -893,7 +893,15 @@ def test_stac_search(post):
     assert len(stac_search("https://a_stac.api/search", {}, max_items=2, limit=1)) == 2
     assert post.call_count == 2
     post.reset_mock()
+    stac_search.cache_clear()
 
+    post.side_effect = [
+        STACMockResponse({"features": [{"id": "1"}], "numberMatched": 2, "numberReturned": 1, "context": {}}),
+        STACMockResponse({"features": [{"id": "2"}], "numberMatched": 2, "numberReturned": 1, "context": {}}),
+    ]
+    assert len(stac_search("https://a_stac.api/search", {}, max_items=2, limit=1)) == 2
+    assert post.call_count == 2
+    post.reset_mock()
 
 
 def test_stac_accessor():


### PR DESCRIPTION
Resolves #231 

- Supports optional `numberMatched` and `numberReturned` as part of ItemCollection response defined in STAC API spec https://github.com/radiantearth/stac-api-spec/blob/604ade6158de15b8ab068320ca41e25e2bf0e116/ogcapi-features/openapi-features.yaml#L303
- Handle case where `matched` field not present in `context` object (pgstac?)
- Will be compatible with pgstac responses which deprecates `context` in favour of `numberMatched `https://stac-utils.github.io/pgstac/release-notes/#unreleased
